### PR TITLE
Parse commands

### DIFF
--- a/cmd/taskmasterd/process.go
+++ b/cmd/taskmasterd/process.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 	"os/exec"
 	"time"
 
@@ -131,7 +132,8 @@ func NewProcess(id string, program *Program) *Process {
 }
 
 func (process *Process) Init() error {
-	parsedCommand, err := parser.ParseCommand(process.Program.Config.Cmd)
+	expandedCommand := os.ExpandEnv(process.Program.Config.Cmd)
+	parsedCommand, err := parser.ParseCommand(expandedCommand)
 	if err != nil {
 		return err
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -20,7 +20,6 @@ const (
 	parserEventCharacter  machine.EventType = "in-word"
 
 	parserEventDoubleQuote machine.EventType = "double-quote"
-	parserEvent
 
 	parserEventSingleQuote machine.EventType = "single-quote"
 	parserEventEnd         machine.EventType = "end"

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,0 +1,250 @@
+package parser
+
+import (
+	"fmt"
+	"unicode"
+
+	"github.com/VisorRaptors/taskmaster/machine"
+)
+
+const (
+	parserStateWhitespace         machine.StateType = "WHITESPACE"
+	parserStateInWord             machine.StateType = "IN_WORD"
+	parserStateInWordDoubleQuoted machine.StateType = "IN_WORD_DOUBLE_QUOTED"
+	parserStateInWordSingleQuoted machine.StateType = "IN_WORD_SINGLE_QUOTED"
+	parserStateEnd                machine.StateType = "END"
+)
+
+const (
+	parserEventWhitespace machine.EventType = "whitespace"
+	parserEventCharacter  machine.EventType = "in-word"
+
+	parserEventDoubleQuote machine.EventType = "double-quote"
+	parserEvent
+
+	parserEventSingleQuote machine.EventType = "single-quote"
+	parserEventEnd         machine.EventType = "end"
+)
+
+// ErrParsing holds the identifier that caused a problem
+// and an error describing the issue.
+type ErrParsing struct {
+	Identifier string
+	Err        error
+}
+
+func (err *ErrParsing) Error() string {
+	return fmt.Sprintf(
+		"parsing error for character: %s: %s",
+		err.Identifier,
+		err.Err.Error(),
+	)
+}
+
+func (err *ErrParsing) Unwrap() error {
+	return err.Err
+}
+
+type parserContext struct {
+	In          string
+	CurrentChar *rune
+
+	ProcessedChunks *[]string
+	CurrentChunk    string
+}
+
+// ParsedCommand holds the command to execute and the arguments to
+// pass to it.
+type ParsedCommand struct {
+	Cmd  string
+	Args []string
+}
+
+// ParseCommand takes a raw command line and returns what is
+// the command to execute and what are the arguments to pass
+// to the command.
+func ParseCommand(cmd string) (ParsedCommand, error) {
+	var (
+		chunks []string
+		char   rune
+	)
+
+	parserMachine := machine.Machine{
+		Context: &parserContext{
+			In:          cmd,
+			CurrentChar: &char,
+
+			ProcessedChunks: &chunks,
+		},
+
+		Initial: parserStateWhitespace,
+
+		StateNodes: machine.StateNodes{
+			parserStateWhitespace: machine.StateNode{
+				Actions: []machine.Action{
+					parserStateWhitespaceAction,
+				},
+
+				On: machine.Events{
+					parserEventWhitespace:  parserStateWhitespace,
+					parserEventCharacter:   parserStateInWord,
+					parserEventDoubleQuote: parserStateInWordDoubleQuoted,
+					parserEventSingleQuote: parserStateInWordSingleQuoted,
+					parserEventEnd:         parserStateEnd,
+				},
+			},
+
+			parserStateInWord: machine.StateNode{
+				Actions: []machine.Action{
+					parserStateInWordAction,
+				},
+
+				On: machine.Events{
+					parserEventWhitespace:  parserStateWhitespace,
+					parserEventCharacter:   parserStateInWord,
+					parserEventDoubleQuote: parserStateInWordDoubleQuoted,
+					parserEventSingleQuote: parserStateInWordSingleQuoted,
+					parserEventEnd:         parserStateEnd,
+				},
+			},
+
+			parserStateInWordDoubleQuoted: machine.StateNode{
+				Actions: []machine.Action{
+					parserStateInWordDoubleQuotedAction,
+				},
+
+				On: machine.Events{
+					parserEventWhitespace:  parserStateInWordDoubleQuoted,
+					parserEventCharacter:   parserStateInWordDoubleQuoted,
+					parserEventSingleQuote: parserStateInWordDoubleQuoted,
+
+					parserEventDoubleQuote: parserStateInWord,
+				},
+			},
+
+			parserStateInWordSingleQuoted: machine.StateNode{
+				Actions: []machine.Action{
+					parserStateInWordSingleQuotedAction,
+				},
+
+				On: machine.Events{
+					parserEventWhitespace:  parserStateInWordSingleQuoted,
+					parserEventCharacter:   parserStateInWordSingleQuoted,
+					parserEventDoubleQuote: parserStateInWordSingleQuoted,
+
+					parserEventSingleQuote: parserStateInWord,
+				},
+			},
+
+			parserStateEnd: machine.StateNode{
+				Actions: []machine.Action{
+					parserStateEndAction,
+				},
+			},
+		},
+	}
+	parserMachine.Init()
+
+	for _, char = range cmd {
+		var event machine.EventType
+
+		switch {
+		case unicode.IsSpace(char):
+			event = parserEventWhitespace
+		case char == '"':
+			event = parserEventDoubleQuote
+		case char == '\'':
+			event = parserEventSingleQuote
+		case unicode.IsPrint(char):
+			event = parserEventCharacter
+		default:
+			continue
+		}
+
+		_, err := parserMachine.Send(event)
+		if err != nil {
+			return ParsedCommand{}, &ErrParsing{
+				Identifier: string(char),
+				Err:        err,
+			}
+		}
+	}
+	_, err := parserMachine.Send(parserEventEnd)
+	if err != nil {
+		return ParsedCommand{}, &ErrParsing{
+			Identifier: "EOF",
+			Err:        err,
+		}
+	}
+
+	if len(chunks) == 0 {
+		return ParsedCommand{}, nil
+	}
+
+	return ParsedCommand{
+		Cmd:  chunks[0],
+		Args: chunks[1:],
+	}, nil
+}
+
+func parserStateWhitespaceAction(context machine.Context) (machine.EventType, error) {
+	ctx := context.(*parserContext)
+
+	if ctx.CurrentChunk == "" {
+		return machine.NoopEvent, nil
+	}
+
+	*ctx.ProcessedChunks = append(*ctx.ProcessedChunks, ctx.CurrentChunk)
+	ctx.CurrentChunk = ""
+
+	return machine.NoopEvent, nil
+}
+
+func parserStateInWordAction(context machine.Context) (machine.EventType, error) {
+	ctx := context.(*parserContext)
+
+	if *ctx.CurrentChar == '"' || *ctx.CurrentChar == '\'' {
+		return machine.NoopEvent, nil
+	}
+
+	ctx.CurrentChunk += string(*ctx.CurrentChar)
+
+	return machine.NoopEvent, nil
+}
+
+func parserStateInWordDoubleQuotedAction(context machine.Context) (machine.EventType, error) {
+	ctx := context.(*parserContext)
+
+	if *ctx.CurrentChar == '"' {
+		return machine.NoopEvent, nil
+	}
+
+	ctx.CurrentChunk += string(*ctx.CurrentChar)
+
+	return machine.NoopEvent, nil
+}
+
+func parserStateInWordSingleQuotedAction(context machine.Context) (machine.EventType, error) {
+	ctx := context.(*parserContext)
+
+	if *ctx.CurrentChar == '\'' {
+		return machine.NoopEvent, nil
+	}
+
+	ctx.CurrentChunk += string(*ctx.CurrentChar)
+
+	return machine.NoopEvent, nil
+}
+
+func parserStateEndAction(context machine.Context) (machine.EventType, error) {
+	ctx := context.(*parserContext)
+
+	if ctx.CurrentChunk == "" {
+		return machine.NoopEvent, nil
+	}
+
+	*ctx.ProcessedChunks = append(*ctx.ProcessedChunks, ctx.CurrentChunk)
+	ctx.CurrentChunk = ""
+
+	return machine.NoopEvent, nil
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,0 +1,443 @@
+package parser_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/VisorRaptors/taskmaster/machine"
+	"github.com/VisorRaptors/taskmaster/parser"
+)
+
+func StringSlicesEqual(a, b []string) bool {
+	for index := range a {
+		if a[index] != b[index] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestParsesEmptyString(t *testing.T) {
+	const in = ""
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = ""
+		expectedArgs = []string{}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}
+
+func TestParsesCommandWithOnlyWhitespaces(t *testing.T) {
+	const in = "         \t \n    \n   \t   "
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = ""
+		expectedArgs = []string{}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}
+
+func TestParsesSingleWord(t *testing.T) {
+	const in = "ls"
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = "ls"
+		expectedArgs = []string{}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}
+
+func TestParsesTwoWords(t *testing.T) {
+	const in = "ls aa"
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = "ls"
+		expectedArgs = []string{
+			"aa",
+		}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}
+
+func TestParsesTwoWordsWithSeveralSeparatingWhitespaces(t *testing.T) {
+	const in = "ls       \t       aa"
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = "ls"
+		expectedArgs = []string{
+			"aa",
+		}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}
+
+func TestParsesWordsWithLeadingAndEndingWhitespaces(t *testing.T) {
+	const in = "    ls  a  \t"
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = "ls"
+		expectedArgs = []string{
+			"a",
+		}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}
+
+func TestParsesSingleQuotes(t *testing.T) {
+	const in = `ls 'salut toi !'`
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = "ls"
+		expectedArgs = []string{
+			"salut toi !",
+		}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}
+
+func TestParsesThrowsOnUncompleteSingleQuoting(t *testing.T) {
+	const in = `ls 'hi !`
+
+	_, err := parser.ParseCommand(in)
+	if err == nil {
+		t.Fatalf(
+			"expected an error to be returned; no error returned",
+		)
+	}
+
+	if !errors.Is(err, machine.ErrInvalidTransitionNotImplemented) {
+		t.Fatalf(
+			"expected a state machine error caused by a not implemented transition; received %v",
+			err,
+		)
+	}
+}
+
+func TestParsesSuccessiveSingleQuotes(t *testing.T) {
+	const in = `ls 'salut toi !''et oui toi !'`
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = "ls"
+		expectedArgs = []string{
+			"salut toi !et oui toi !",
+		}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}
+
+func TestParsesDoubleQuotes(t *testing.T) {
+	const in = `ls "salut toi !"`
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = "ls"
+		expectedArgs = []string{
+			"salut toi !",
+		}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}
+
+func TestParsesThrowsOnUncompleteDoubleQuoting(t *testing.T) {
+	const in = `ls "hi !`
+
+	_, err := parser.ParseCommand(in)
+	if err == nil {
+		t.Fatalf(
+			"expected an error to be returned; no error returned",
+		)
+	}
+
+	if !errors.Is(err, machine.ErrInvalidTransitionNotImplemented) {
+		t.Fatalf(
+			"expected a state machine error caused by a not implemented transition; received %v",
+			err,
+		)
+	}
+}
+
+func TestIgnoresNotPrintableCharacters(t *testing.T) {
+	const in = "ls \x02\x03\x04\x7f"
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = "ls"
+		expectedArgs = []string{}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}
+
+func TestParsesWtfSuccessiveDoubleAndSingleQuoting(t *testing.T) {
+	const in = `ls "salut toi !"'yolo   yolo"lol"'"et oui toi !"`
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = "ls"
+		expectedArgs = []string{
+			`salut toi !yolo   yolo"lol"et oui toi !`,
+		}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}
+
+func TestParsesSuccessiveDoubleQuotes(t *testing.T) {
+	const in = `ls "salut toi !""et oui toi !"`
+
+	cmd, err := parser.ParseCommand(in)
+	if err != nil {
+		t.Fatalf(
+			"expected no error to be returned; received %v",
+			err,
+		)
+	}
+
+	var (
+		expectedCmd  = "ls"
+		expectedArgs = []string{
+			"salut toi !et oui toi !",
+		}
+	)
+	if cmd.Cmd != expectedCmd {
+		t.Fatalf(
+			"parsed cmd is incorrect %v; expected %v",
+			cmd.Cmd,
+			expectedCmd,
+		)
+	}
+	if !StringSlicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf(
+			"parsed args are incorrect %v; expected %v",
+			cmd.Args,
+			expectedArgs,
+		)
+	}
+}


### PR DESCRIPTION
We create a package to parse command lines.

We use this package to parse processes command lines.
We expand environment variables from processes command lines.

Closes #10 