### PR TITLE
Change lock file location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '14'
+    - name: Run Go tests
+      run: go test ./...
     - name: Compile tests files
       run: make tests
     - name: Install tests Node.js dependencies

--- a/cmd/taskmasterd/lock.go
+++ b/cmd/taskmasterd/lock.go
@@ -1,10 +1,23 @@
 package main
 
-import "os"
+import (
+	"log"
+	"os"
+	"path"
+)
 
-const lockFilePath = "./taskmasterd.lock"
+func getLockFilePath() string {
+	const lockFileName = "taskmasterd.lock"
+
+	tmpDir := os.TempDir()
+
+	return path.Join(tmpDir, lockFileName)
+}
 
 func lockFileExists() bool {
+	lockFilePath := getLockFilePath()
+	log.Println("lock file path", lockFilePath)
+
 	_, err := os.Stat(lockFilePath)
 	if err == nil {
 		return true
@@ -13,9 +26,15 @@ func lockFileExists() bool {
 }
 
 func lockFileCreate() {
+	lockFilePath := getLockFilePath()
+	log.Println("lock file path", lockFilePath)
+
 	os.Create(lockFilePath)
 }
 
 func lockFileRemove() {
+	lockFilePath := getLockFilePath()
+	log.Println("lock file path", lockFilePath)
+
 	os.Remove(lockFilePath)
 }

--- a/cmd/taskmasterd/lock_test.go
+++ b/cmd/taskmasterd/lock_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestGetLockFilePathIsInIdempotent(t *testing.T) {
+	const iterations = 100
+
+	var lastLockFilePath string
+
+	for index := 0; index < iterations; index++ {
+		if index == 0 {
+			lastLockFilePath = getLockFilePath()
+			continue
+		}
+
+		if newLockFilePath := getLockFilePath(); newLockFilePath != lastLockFilePath {
+			t.Fatalf(
+				"unexpected value returned %v; expected getLockFilePath to be idempotent and return %v",
+				newLockFilePath,
+				lastLockFilePath,
+			)
+		}
+	}
+}


### PR DESCRIPTION
We get user's temporary directory path and join it with the name of the lockfile, that is `taskmasterd.d`.

We added a test to test idempotent behaviour of `os.TempDir`.

We made our CI run Go tests.

Closes #22 