### PR TITLE
Close Command stdout and stderr opened files

### DIFF
--- a/cmd/taskmasterd/process.go
+++ b/cmd/taskmasterd/process.go
@@ -14,9 +14,10 @@ type Process struct {
 	Context         context.Context
 	ProgramTaskChan chan<- Tasker
 
-	TaskActionChan chan TaskAction
-	Cmd            *exec.Cmd
-	Machine        *machine.Machine
+	TaskActionChan           chan TaskAction
+	Cmd                      *exec.Cmd
+	stdoutClose, stderrClose func() error
+	Machine                  *machine.Machine
 
 	DeadCh *chan struct{}
 }
@@ -129,4 +130,16 @@ func (process *Process) Wait() {
 	if process.DeadCh != nil {
 		<-*process.DeadCh
 	}
+}
+
+func (process *Process) CloseFileDescriptors() error {
+	if err := process.stdoutClose(); err != nil {
+		return err
+	}
+
+	if err := process.stderrClose(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/taskmasterd/yaml.go
+++ b/cmd/taskmasterd/yaml.go
@@ -98,7 +98,7 @@ func (config *ProgramConfiguration) CreateCmdEnvironment() []string {
 	return env
 }
 
-func (config *ProgramConfiguration) CreateCmdStdout(processID string) (io.Writer, error) {
+func (config *ProgramConfiguration) CreateCmdStdout(processID string) (io.WriteCloser, error) {
 	if len(config.Stdout) == 0 || config.Stdout == "NONE" {
 		return nil, nil
 	}
@@ -115,7 +115,7 @@ func (config *ProgramConfiguration) CreateCmdStdout(processID string) (io.Writer
 	return file, nil
 }
 
-func (config *ProgramConfiguration) CreateCmdStderr(processID string) (io.Writer, error) {
+func (config *ProgramConfiguration) CreateCmdStderr(processID string) (io.WriteCloser, error) {
 	if len(config.Stderr) == 0 || config.Stderr == "NONE" {
 		return nil, nil
 	}


### PR DESCRIPTION
When the process dies, close its stdout and stderr opened files.