### PR TITLE
Keep track of processes start and stop time and return it from the API

### DIFF
--- a/cmd/taskmasterd/http.go
+++ b/cmd/taskmasterd/http.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/42Taskmaster/taskmaster/machine"
 )
@@ -44,10 +45,12 @@ type HttpProgram struct {
 }
 
 type HttpProcess struct {
-	Id     string            `json:"id"`
-	Pid    int               `json:"pid"`
-	State  machine.StateType `json:"state"`
-	Uptime int               `json:"uptime"`
+	Id    string            `json:"id"`
+	Pid   int               `json:"pid"`
+	State machine.StateType `json:"state"`
+
+	StartedAt time.Time `json:"startedAt"`
+	EndedAt   time.Time `json:"endedAt"`
 }
 type HttpConfiguration struct {
 	Data string `json:"data"`
@@ -88,6 +91,9 @@ func httpEndpointStatus(taskmasterd *Taskmasterd, w http.ResponseWriter, r *http
 						Id:    process.ID,
 						Pid:   pid,
 						State: process.Machine.Current(),
+
+						StartedAt: *process.StartedAt,
+						EndedAt:   *process.EndedAt,
 					}
 					httpProgram.Processes = append(httpProgram.Processes, httpProcess)
 				}

--- a/cmd/taskmasterd/process.go
+++ b/cmd/taskmasterd/process.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"log"
 	"os/exec"
 	"syscall"
 	"time"
@@ -51,15 +50,11 @@ func NewProcess(args NewProcessArgs) Process {
 }
 
 func (process *Process) StartChronometer() {
-	log.Println("StartChronometer called", process)
-
 	*process.StartedAt = time.Now()
 	*process.EndedAt = time.Time{}
 }
 
 func (process *Process) StopChronometer() {
-	log.Println("StopChronometer called", process)
-
 	*process.EndedAt = time.Now()
 }
 

--- a/cmd/taskmasterd/process.go
+++ b/cmd/taskmasterd/process.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"log"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/42Taskmaster/taskmaster/machine"
 )
@@ -18,6 +20,7 @@ type Process struct {
 	Cmd                      *exec.Cmd
 	stdoutClose, stderrClose func() error
 	Machine                  *machine.Machine
+	StartedAt, EndedAt       *time.Time
 
 	DeadCh *chan struct{}
 }
@@ -35,6 +38,9 @@ func NewProcess(args NewProcessArgs) Process {
 		ProgramTaskChan: args.ProgramTaskChan,
 
 		TaskActionChan: make(chan TaskAction),
+
+		StartedAt: &time.Time{},
+		EndedAt:   &time.Time{},
 	}
 
 	process.Machine = NewProcessMachine(&process)
@@ -42,6 +48,19 @@ func NewProcess(args NewProcessArgs) Process {
 	go process.Monitor()
 
 	return process
+}
+
+func (process *Process) StartChronometer() {
+	log.Println("StartChronometer called", process)
+
+	*process.StartedAt = time.Now()
+	*process.EndedAt = time.Time{}
+}
+
+func (process *Process) StopChronometer() {
+	log.Println("StopChronometer called", process)
+
+	*process.EndedAt = time.Now()
 }
 
 func (process *Process) Monitor() {

--- a/cmd/taskmasterd/process_actions.go
+++ b/cmd/taskmasterd/process_actions.go
@@ -67,6 +67,8 @@ func ProcessStartAction(context machine.Context) (machine.EventType, error) {
 	}
 	ResetUmask()
 
+	process.StartChronometer()
+
 	deadCh := make(chan struct{})
 	process.DeadCh = &deadCh
 
@@ -83,6 +85,8 @@ func ProcessStartAction(context machine.Context) (machine.EventType, error) {
 		process.Cmd.Wait()
 
 		close(deadCh)
+
+		process.StopChronometer()
 
 		if err := process.CloseFileDescriptors(); err != nil {
 			log.Printf(


### PR DESCRIPTION
We directly return the `time.Time` properties (transformed into ISO Date string through JSON Marshaler) to let the clients make what they want with these information.