### PR TITLE
Use CSP with RPC to access and modify Process fields

### DIFF
--- a/cmd/taskmasterd/http.go
+++ b/cmd/taskmasterd/http.go
@@ -45,7 +45,7 @@ type HttpProgram struct {
 }
 
 type HttpProcess struct {
-	Id    string            `json:"id"`
+	ID    string            `json:"id"`
 	Pid   int               `json:"pid"`
 	State machine.StateType `json:"state"`
 
@@ -84,16 +84,19 @@ func httpEndpointStatus(taskmasterd *Taskmasterd, w http.ResponseWriter, r *http
 				}
 				for _, process := range processes {
 					pid := 0
-					if process.Cmd != nil && process.Cmd.Process != nil {
-						pid = process.Cmd.Process.Pid
+					if cmd := process.GetCmd(); cmd != nil && cmd.Process != nil {
+						pid = cmd.Process.Pid
 					}
-					httpProcess := HttpProcess{
-						Id:    process.ID,
-						Pid:   pid,
-						State: process.Machine.Current(),
 
-						StartedAt: *process.StartedAt,
-						EndedAt:   *process.EndedAt,
+					serializedProcess := process.Serialize()
+
+					httpProcess := HttpProcess{
+						ID:    serializedProcess.ID,
+						Pid:   pid,
+						State: process.GetStateMachineCurrentState(),
+
+						StartedAt: serializedProcess.StartedAt,
+						EndedAt:   serializedProcess.EndedAt,
 					}
 					httpProgram.Processes = append(httpProgram.Processes, httpProcess)
 				}
@@ -290,6 +293,7 @@ func httpHandleEndpoint(taskmasterd *Taskmasterd, callback HttpEndpointFunc) Htt
 		log.Println(r.RemoteAddr, r.Method, r.RequestURI)
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "*")
 		if r.Method != "OPTIONS" {
 			callback(taskmasterd, w, r)
 		}

--- a/cmd/taskmasterd/process.go
+++ b/cmd/taskmasterd/process.go
@@ -9,19 +9,45 @@ import (
 	"github.com/42Taskmaster/taskmaster/machine"
 )
 
+type ProcessSerialized struct {
+	ID                 string
+	State              machine.StateType
+	StartedAt, EndedAt time.Time
+}
+
+type Processer interface {
+	GetConfig() (ProgramConfiguration, error)
+	GetContext() context.Context
+	GetStateMachineCurrentState() machine.StateType
+	GetCmd() *exec.Cmd
+	SetCmd(*exec.Cmd)
+	SetStdoutStderrCloser(stdoutClose, stderrClose func() error)
+	CloseFileDescriptors() error
+	StartChronometer()
+	StopChronometer()
+	Start()
+	Stop()
+	Restart()
+	Kill()
+	Wait()
+	GetDeadChannel() chan struct{}
+	CreateNewDeadChannel() chan struct{}
+	Serialize() ProcessSerialized
+}
+
 type Process struct {
-	ID string
+	id string
 
-	Context         context.Context
-	ProgramTaskChan chan<- Tasker
+	context               context.Context
+	programMonitorChannel chan<- Tasker
 
-	TaskActionChan           chan TaskAction
-	Cmd                      *exec.Cmd
-	stdoutClose, stderrClose func() error
-	Machine                  *machine.Machine
-	StartedAt, EndedAt       *time.Time
+	externalMonitorChannel, internalMonitorChannel chan Tasker
+	cmd                                            *exec.Cmd
+	stdoutClose, stderrClose                       func() error
+	machine                                        *machine.Machine
+	startedAt, endedAt                             time.Time
 
-	DeadCh *chan struct{}
+	deadCh chan struct{}
 }
 
 type NewProcessArgs struct {
@@ -30,130 +56,433 @@ type NewProcessArgs struct {
 	ProgramTaskChan chan<- Tasker
 }
 
-func NewProcess(args NewProcessArgs) Process {
-	process := Process{
-		ID:              args.ID,
-		Context:         args.Context,
-		ProgramTaskChan: args.ProgramTaskChan,
+func NewProcess(args NewProcessArgs) *Process {
+	process := &Process{
+		id:                    args.ID,
+		context:               args.Context,
+		programMonitorChannel: args.ProgramTaskChan,
 
-		TaskActionChan: make(chan TaskAction),
-
-		StartedAt: &time.Time{},
-		EndedAt:   &time.Time{},
+		externalMonitorChannel: make(chan Tasker),
+		internalMonitorChannel: make(chan Tasker),
 	}
 
-	process.Machine = NewProcessMachine(&process)
+	process.machine = NewProcessMachine(process)
 
-	go process.Monitor()
+	go process.monitor()
 
 	return process
 }
 
-func (process *Process) StartChronometer() {
-	*process.StartedAt = time.Now()
-	*process.EndedAt = time.Time{}
-}
-
-func (process *Process) StopChronometer() {
-	*process.EndedAt = time.Now()
-}
-
-func (process *Process) Monitor() {
+func (process *Process) monitor() {
 	for {
 		select {
-		case <-process.Context.Done():
+		case <-process.context.Done():
 			return
-		case action := <-process.TaskActionChan:
-			switch action {
+
+		case task := <-process.externalMonitorChannel:
+			switch action := task.GetAction(); action {
 			case ProcessTaskActionStart:
-				process.Machine.Send(ProcessEventStart)
+				go process.machine.Send(ProcessEventStart)
 			case ProcessTaskActionStop:
-				process.Machine.Send(ProcessEventStop)
+				go process.machine.Send(ProcessEventStop)
+			case ProcessTaskActionRestart:
+				go func() {
+					process.machine.Send(ProcessEventStop)
+					<-process.deadCh
+					process.machine.Send(ProcessEventStart)
+				}()
 			case ProcessTaskActionKill:
-				process.Cmd.Process.Signal(syscall.SIGKILL)
+				go process.cmd.Process.Signal(syscall.SIGKILL)
+			}
+
+		case task := <-process.internalMonitorChannel:
+			switch action := task.GetAction(); action {
+			case ProcessTaskActionStartChronometer:
+				process.startedAt = time.Now()
+				process.endedAt = time.Time{}
+			case ProcessTaskActionStopChronometer:
+				process.endedAt = time.Now()
+			case ProcessTaskActionGetProgramConfig:
+				taskWithResponse := task.(ProcessInternalTaskWithResponse)
+				responseChan := taskWithResponse.ResponseChan
+				programResponseChan := make(chan interface{})
+
+				select {
+				case process.programMonitorChannel <- ProgramTaskRootActionWithResponse{
+					ProgramTaskRootAction: ProgramTaskRootAction{
+						TaskBase: TaskBase{
+							Action: ProgramTaskActionGetConfig,
+						},
+					},
+
+					ResponseChan: programResponseChan,
+				}:
+				case <-process.context.Done():
+					responseChan <- nil
+					break
+				}
+
+				select {
+				case res := <-programResponseChan:
+					config := res.(ProgramConfiguration)
+
+					responseChan <- config
+
+					close(responseChan)
+				case <-process.context.Done():
+					responseChan <- nil
+				}
+			case ProcessTaskActionSerialize:
+				taskWithResponse := task.(ProcessInternalTaskWithResponse)
+				responseChan := taskWithResponse.ResponseChan
+
+				responseChan <- ProcessSerialized{
+					ID:        process.id,
+					State:     process.machine.UnsafeCurrent(),
+					StartedAt: process.startedAt,
+					EndedAt:   process.endedAt,
+				}
+
+				close(responseChan)
+			case ProcessTaskActionCreateNewDeadChannel:
+				taskWithResponse := task.(ProcessInternalTaskWithResponse)
+				responseChan := taskWithResponse.ResponseChan
+
+				newDeadChannel := make(chan struct{})
+
+				process.deadCh = newDeadChannel
+
+				responseChan <- newDeadChannel
+
+				close(responseChan)
+			case ProcessTaskActionGetCmd:
+				taskWithResponse := task.(ProcessInternalTaskWithResponse)
+				responseChan := taskWithResponse.ResponseChan
+
+				responseChan <- process.cmd
+
+				close(responseChan)
+			case ProcessTaskActionGetDeadChannel:
+				taskWithResponse := task.(ProcessInternalTaskWithResponse)
+				responseChan := taskWithResponse.ResponseChan
+
+				responseChan <- process.deadCh
+
+				close(responseChan)
+			case ProcessTaskActionGetStateMachineCurrentState:
+				taskWithResponse := task.(ProcessInternalTaskWithResponse)
+				responseChan := taskWithResponse.ResponseChan
+
+				responseChan <- process.machine.Current()
+
+				close(responseChan)
+			case ProcessTaskActionSetCmd:
+				taskWithResponse := task.(ProcessInternalTaskWithPayload)
+				cmd := taskWithResponse.Payload.(*exec.Cmd)
+
+				process.cmd = cmd
+			case ProcessTaskActionSetStdoutStderrCloser:
+				taskWithResponse := task.(ProcessInternalTaskWithPayload)
+				closers := taskWithResponse.Payload.([]func() error)
+				stdoutClose := closers[0]
+				stderrClose := closers[1]
+
+				process.stdoutClose = stdoutClose
+				process.stderrClose = stderrClose
+			case ProcessTaskActionCloseFileDescriptors:
+				taskWithResponse := task.(ProcessInternalTaskWithResponse)
+				responseChan := taskWithResponse.ResponseChan
+
+				if err := process.stdoutClose(); err != nil {
+					responseChan <- err
+					break
+				}
+
+				if err := process.stderrClose(); err != nil {
+					responseChan <- err
+					break
+				}
+
+				responseChan <- nil
 			}
 		}
 	}
 }
 
-func (process *Process) Start() error {
-	select {
-	case process.TaskActionChan <- ProcessTaskActionStart:
-		return nil
-	case <-process.Context.Done():
-		return ErrChannelClosed
-	}
+func (process *Process) GetContext() context.Context {
+	return process.context
 }
 
-func (process *Process) Stop() error {
-	select {
-	case process.TaskActionChan <- ProcessTaskActionStop:
-		return nil
-	case <-process.Context.Done():
-		return ErrChannelClosed
-	}
+func (process *Process) StartChronometer() {
+	go func() {
+		select {
+		case process.internalMonitorChannel <- ProcessTaskActionStartChronometer:
+			return
+		case <-process.context.Done():
+			return
+		}
+	}()
 }
 
-func (process *Process) Restart() error {
-	if err := process.Start(); err != nil {
-		return err
-	}
-	if err := process.Stop(); err != nil {
-		return err
-	}
-	return nil
+func (process *Process) StopChronometer() {
+	go func() {
+		select {
+		case process.internalMonitorChannel <- ProcessTaskActionStopChronometer:
+			return
+		case <-process.context.Done():
+			return
+		}
+	}()
 }
 
-func (process *Process) Kill() error {
-	select {
-	case process.TaskActionChan <- ProcessTaskActionKill:
-		return nil
-	case <-process.Context.Done():
-		return ErrChannelClosed
-	}
+func (process *Process) Start() {
+	go func() {
+		select {
+		case process.externalMonitorChannel <- ProcessTaskActionStart:
+			return
+		case <-process.context.Done():
+			return
+		}
+	}()
+}
+
+func (process *Process) Stop() {
+	go func() {
+		select {
+		case process.externalMonitorChannel <- ProcessTaskActionStop:
+			return
+		case <-process.context.Done():
+			return
+		}
+	}()
+}
+
+func (process *Process) Restart() {
+	go func() {
+		select {
+		case process.externalMonitorChannel <- ProcessTaskActionRestart:
+			return
+		case <-process.context.Done():
+			return
+		}
+	}()
+}
+
+func (process *Process) Kill() {
+	go func() {
+		select {
+		case process.externalMonitorChannel <- ProcessTaskActionKill:
+			return
+		case <-process.context.Done():
+			return
+		}
+	}()
 }
 
 func (process *Process) GetConfig() (ProgramConfiguration, error) {
 	responseChan := make(chan interface{})
 
 	select {
-	case process.ProgramTaskChan <- ProgramTaskRootActionWithResponse{
-		ProgramTaskRootAction: ProgramTaskRootAction{
-			TaskBase: TaskBase{
-				Action: ProgramTaskActionGetConfig,
-			},
+	case process.internalMonitorChannel <- ProcessInternalTaskWithResponse{
+		TaskBase: TaskBase{
+			Action: ProcessTaskActionGetProgramConfig,
 		},
-
 		ResponseChan: responseChan,
 	}:
-	case <-process.Context.Done():
+	case <-process.context.Done():
 		return ProgramConfiguration{}, ErrChannelClosed
 	}
 
 	select {
-	case res := <-responseChan:
-		config := res.(ProgramConfiguration)
+	case resp := <-responseChan:
+		if resp == nil {
+			return ProgramConfiguration{}, ErrChannelClosed
+		}
 
+		config := resp.(ProgramConfiguration)
 		return config, nil
-	case <-process.Context.Done():
+	case <-process.context.Done():
 		return ProgramConfiguration{}, ErrChannelClosed
 	}
 }
 
+func (process *Process) Serialize() ProcessSerialized {
+	responseChan := make(chan interface{})
+
+	select {
+	case process.internalMonitorChannel <- ProcessInternalTaskWithResponse{
+		TaskBase: TaskBase{
+			Action: ProcessTaskActionSerialize,
+		},
+		ResponseChan: responseChan,
+	}:
+	case <-process.context.Done():
+		return ProcessSerialized{}
+	}
+
+	select {
+	case resp := <-responseChan:
+		serializedProcess := resp.(ProcessSerialized)
+		return serializedProcess
+	case <-process.context.Done():
+		return ProcessSerialized{}
+	}
+}
+
+func (process *Process) CreateNewDeadChannel() chan struct{} {
+	responseChan := make(chan interface{})
+
+	select {
+	case process.internalMonitorChannel <- ProcessInternalTaskWithResponse{
+		TaskBase: TaskBase{
+			Action: ProcessTaskActionCreateNewDeadChannel,
+		},
+		ResponseChan: responseChan,
+	}:
+	case <-process.context.Done():
+		return nil
+	}
+
+	select {
+	case resp := <-responseChan:
+		serializedProcess := resp.(chan struct{})
+		return serializedProcess
+	case <-process.context.Done():
+		return nil
+	}
+}
+
+func (process *Process) GetCmd() *exec.Cmd {
+	responseChan := make(chan interface{})
+
+	select {
+	case process.internalMonitorChannel <- ProcessInternalTaskWithResponse{
+		TaskBase: TaskBase{
+			Action: ProcessTaskActionGetCmd,
+		},
+		ResponseChan: responseChan,
+	}:
+	case <-process.context.Done():
+		return nil
+	}
+
+	select {
+	case resp := <-responseChan:
+		cmd := resp.(*exec.Cmd)
+		return cmd
+	case <-process.context.Done():
+		return nil
+	}
+}
+
+func (process *Process) GetDeadChannel() chan struct{} {
+	responseChan := make(chan interface{})
+
+	select {
+	case process.internalMonitorChannel <- ProcessInternalTaskWithResponse{
+		TaskBase: TaskBase{
+			Action: ProcessTaskActionGetDeadChannel,
+		},
+		ResponseChan: responseChan,
+	}:
+	case <-process.context.Done():
+		return nil
+	}
+
+	select {
+	case resp := <-responseChan:
+		deadCh := resp.(chan struct{})
+		return deadCh
+	case <-process.context.Done():
+		return nil
+	}
+}
+
+func (process *Process) GetStateMachineCurrentState() machine.StateType {
+	responseChan := make(chan interface{})
+
+	select {
+	case process.internalMonitorChannel <- ProcessInternalTaskWithResponse{
+		TaskBase: TaskBase{
+			Action: ProcessTaskActionGetStateMachineCurrentState,
+		},
+		ResponseChan: responseChan,
+	}:
+	case <-process.context.Done():
+		return machine.NoopState
+	}
+
+	select {
+	case resp := <-responseChan:
+		stateMachine := resp.(machine.StateType)
+		return stateMachine
+	case <-process.context.Done():
+		return machine.NoopState
+	}
+}
+
+func (process *Process) SetCmd(cmd *exec.Cmd) {
+	go func() {
+		select {
+		case process.internalMonitorChannel <- ProcessInternalTaskWithPayload{
+			TaskBase: TaskBase{
+				Action: ProcessTaskActionSetCmd,
+			},
+			Payload: cmd,
+		}:
+		case <-process.context.Done():
+			return
+		}
+	}()
+}
+
+func (process *Process) SetStdoutStderrCloser(stdoutClose, stderrClose func() error) {
+	go func() {
+		select {
+		case process.internalMonitorChannel <- ProcessInternalTaskWithPayload{
+			TaskBase: TaskBase{
+				Action: ProcessTaskActionSetStdoutStderrCloser,
+			},
+			Payload: []func() error{
+				stdoutClose,
+				stderrClose,
+			},
+		}:
+		case <-process.context.Done():
+			return
+		}
+	}()
+}
+
 func (process *Process) Wait() {
-	if process.DeadCh != nil {
-		<-*process.DeadCh
+	if deadCh := process.GetDeadChannel(); deadCh != nil {
+		<-deadCh
 	}
 }
 
 func (process *Process) CloseFileDescriptors() error {
-	if err := process.stdoutClose(); err != nil {
-		return err
+	responseChan := make(chan interface{})
+
+	select {
+	case process.internalMonitorChannel <- ProcessInternalTaskWithResponse{
+		TaskBase: TaskBase{
+			Action: ProcessTaskActionCloseFileDescriptors,
+		},
+		ResponseChan: responseChan,
+	}:
+	case <-process.context.Done():
+		return nil
 	}
 
-	if err := process.stderrClose(); err != nil {
-		return err
-	}
+	select {
+	case resp := <-responseChan:
+		if resp == nil {
+			return nil
+		}
 
-	return nil
+		err := resp.(error)
+		return err
+	case <-process.context.Done():
+		return nil
+	}
 }

--- a/cmd/taskmasterd/process_actions.go
+++ b/cmd/taskmasterd/process_actions.go
@@ -10,180 +10,6 @@ import (
 	"github.com/42Taskmaster/taskmaster/parser"
 )
 
-func ProcessStartAction(context machine.Context) (machine.EventType, error) {
-	var (
-		processContext = context.(*ProcessMachineContext)
-		process        = processContext.Process
-	)
-
-	config, err := process.GetConfig()
-	if err != nil {
-		return machine.NoopEvent, err
-	}
-
-	expandedCommand := os.ExpandEnv(config.Cmd)
-	parsedCommand, err := parser.ParseCommand(expandedCommand)
-	if err != nil {
-		return ProcessEventFatal, err
-	}
-
-	cmd := exec.CommandContext(
-		process.Context,
-		parsedCommand.Cmd,
-		parsedCommand.Args...,
-	)
-
-	cmd.Env = config.CreateCmdEnvironment()
-	cmd.Stdin = nil
-
-	stdout, err := config.CreateCmdStdout(process.ID)
-	if err != nil {
-		return ProcessEventFatal, nil
-	}
-	cmd.Stdout = stdout
-	process.stdoutClose = stdout.Close
-
-	stderr, err := config.CreateCmdStderr(process.ID)
-	if err != nil {
-		return ProcessEventFatal, nil
-	}
-	cmd.Stderr = stderr
-	process.stderrClose = stderr.Close
-
-	cmd.Dir = config.Workingdir
-
-	process.Cmd = cmd
-
-	SetUmask(config.Umask)
-	if err := process.Cmd.Start(); err != nil {
-		log.Printf("Error starting process '%s' of program '%s': %s", config.Name, process.ID, err.Error())
-		ResetUmask()
-		return ProcessEventFatal, &ErrProcessAction{
-			ID: process.ID,
-			Err: &ErrProcessStarting{
-				Err: err,
-			},
-		}
-	}
-	ResetUmask()
-
-	process.StartChronometer()
-
-	deadCh := make(chan struct{})
-	process.DeadCh = &deadCh
-
-	go func(deadCh chan struct{}) {
-		select {
-		case <-time.After(time.Duration(config.Starttime) * time.Second):
-			process.Machine.Send(ProcessEventStarted)
-		case <-deadCh:
-			return
-		}
-	}(*process.DeadCh)
-
-	go func(deadCh chan struct{}) {
-		process.Cmd.Wait()
-
-		close(deadCh)
-
-		process.StopChronometer()
-
-		if err := process.CloseFileDescriptors(); err != nil {
-			log.Printf(
-				"error while closing opened file descriptors of stdout and stderr: %v\n",
-				err,
-			)
-		}
-
-		event := ProcessEventStopped
-		if process.Cmd.ProcessState.Exited() {
-			log.Printf("Process '%s' of program '%s' has exited with code %d", process.ID, config.Name, process.Cmd.ProcessState.ExitCode())
-			event = ProcessEventExit
-		}
-
-		_, err := process.Machine.Send(event)
-		if err != nil {
-			log.Printf("expected no error to be returned but got %v\n", err)
-		}
-	}(*process.DeadCh)
-
-	return machine.NoopEvent, nil
-}
-
-func ProcessStopAction(context machine.Context) (machine.EventType, error) {
-	var (
-		processContext = context.(*ProcessMachineContext)
-		process        = processContext.Process
-	)
-
-	config, err := process.GetConfig()
-	if err != nil {
-		return machine.NoopEvent, err
-	}
-
-	err = process.Cmd.Process.Signal(config.Stopsignal.ToOsSignal())
-	if err != nil {
-		return machine.NoopEvent, &ErrProcessAction{
-			ID:  processContext.Process.ID,
-			Err: err,
-		}
-	}
-
-	go func() {
-		select {
-		case <-time.After(time.Duration(config.Stoptime) * time.Second):
-			process.Kill()
-		case <-*process.DeadCh:
-		}
-	}()
-
-	return machine.NoopEvent, nil
-}
-
-func ProcessBackoffAction(context machine.Context) (machine.EventType, error) {
-	processContext := context.(*ProcessMachineContext)
-	process := processContext.Process
-
-	config, err := process.GetConfig()
-	if err != nil {
-		return machine.NoopEvent, err
-	}
-
-	switch config.Autorestart {
-	case AutorestartOn:
-		processContext.Starttries++
-		if processContext.Starttries == config.Startretries {
-			log.Printf("Fatal: could not start process '%s' of program '%s' (%d tries)", process.ID, config.Name, processContext.Starttries)
-			return ProcessEventFatal, nil
-		}
-		log.Printf("Trying to restart process '%s' of program '%s'...", process.ID, config.Name)
-		return ProcessEventStart, nil
-	case AutorestartUnexpected:
-		exitcode := process.Cmd.ProcessState.ExitCode()
-		for _, allowedExitcode := range config.Exitcodes {
-			if exitcode == allowedExitcode {
-				return machine.NoopEvent, nil
-			}
-		}
-		processContext.Starttries++
-		if processContext.Starttries == config.Startretries {
-			log.Printf("Fatal: could not start process '%s' of program '%s' (%d tries)", process.ID, config.Name, processContext.Starttries)
-			return ProcessEventFatal, nil
-		}
-		log.Printf("Trying to restart process '%s' of program '%s'...", process.ID, config.Name)
-		return ProcessEventStart, nil
-	default:
-		return machine.NoopEvent, nil
-	}
-}
-
-func ProcessRunningAction(context machine.Context) (machine.EventType, error) {
-	processContext := context.(*ProcessMachineContext)
-	processContext.Starttries = 0
-
-	return machine.NoopEvent, nil
-}
-
 type ErrProcessAction struct {
 	ID  string
 	Err error
@@ -219,4 +45,215 @@ func (err *ErrProcessStopping) Unwrap() error {
 
 func (err *ErrProcessStopping) Error() string {
 	return "stopping: " + err.Err.Error()
+}
+
+func ProcessStartAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
+	var (
+		processContext = context.(*ProcessMachineContext)
+		process        = processContext.Process
+	)
+
+	config, err := process.GetConfig()
+	if err != nil {
+		return machine.NoopEvent, err
+	}
+
+	expandedCommand := os.ExpandEnv(config.Cmd)
+	parsedCommand, err := parser.ParseCommand(expandedCommand)
+	if err != nil {
+		return ProcessEventFatal, err
+	}
+
+	cmd := exec.CommandContext(
+		process.GetContext(),
+		parsedCommand.Cmd,
+		parsedCommand.Args...,
+	)
+
+	cmd.Env = config.CreateCmdEnvironment()
+	cmd.Stdin = nil
+
+	serializedProcess := process.Serialize()
+
+	stdout, err := config.CreateCmdStdout(serializedProcess.ID)
+	if err != nil {
+		return ProcessEventFatal, nil
+	}
+	cmd.Stdout = stdout
+
+	stderr, err := config.CreateCmdStderr(serializedProcess.ID)
+	if err != nil {
+		return ProcessEventFatal, nil
+	}
+	cmd.Stderr = stderr
+
+	process.SetStdoutStderrCloser(stdout.Close, stderr.Close)
+
+	cmd.Dir = config.Workingdir
+
+	process.SetCmd(cmd)
+
+	SetUmask(config.Umask)
+	if err := cmd.Start(); err != nil {
+		log.Printf(
+			"Error starting process '%s' of program '%s': %s",
+			config.Name,
+			serializedProcess.ID,
+			err.Error(),
+		)
+
+		ResetUmask()
+
+		return ProcessEventFatal, &ErrProcessAction{
+			ID: serializedProcess.ID,
+			Err: &ErrProcessStarting{
+				Err: err,
+			},
+		}
+	}
+	ResetUmask()
+
+	process.StartChronometer()
+
+	deadCh := process.CreateNewDeadChannel()
+
+	go func() {
+		select {
+		case <-time.After(time.Duration(config.Starttime) * time.Second):
+			stateMachine.Send(ProcessEventStarted)
+		case <-deadCh:
+			return
+		}
+	}()
+
+	go func() {
+		// We must close the channel after the state machine has reached another
+		// state. Without that we encounter race conditions on the restart function.
+		defer close(deadCh)
+
+		cmd.Wait()
+
+		process.StopChronometer()
+
+		if err := process.CloseFileDescriptors(); err != nil {
+			log.Printf(
+				"error while closing opened file descriptors of stdout and stderr: %v\n",
+				err,
+			)
+		}
+
+		event := ProcessEventStopped
+		if cmd.ProcessState.Exited() {
+			log.Printf(
+				"Process '%s' of program '%s' has exited with code %d",
+				serializedProcess.ID,
+				config.Name,
+				cmd.ProcessState.ExitCode(),
+			)
+			event = ProcessEventExit
+		}
+
+		_, err := stateMachine.Send(event)
+		if err != nil {
+			log.Printf("expected no error to be returned but got %v\n", err)
+		}
+	}()
+
+	return machine.NoopEvent, nil
+}
+
+func ProcessStopAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
+	var (
+		processContext = context.(*ProcessMachineContext)
+		process        = processContext.Process
+	)
+
+	config, err := process.GetConfig()
+	if err != nil {
+		return machine.NoopEvent, err
+	}
+
+	serializedProcess := process.Serialize()
+
+	err = process.GetCmd().Process.Signal(config.Stopsignal.ToOsSignal())
+	if err != nil {
+		return machine.NoopEvent, &ErrProcessAction{
+			ID:  serializedProcess.ID,
+			Err: err,
+		}
+	}
+
+	go func() {
+		select {
+		case <-time.After(time.Duration(config.Stoptime) * time.Second):
+			process.Kill()
+		case <-process.GetDeadChannel():
+		}
+	}()
+
+	return machine.NoopEvent, nil
+}
+
+func ProcessBackoffAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
+	processContext := context.(*ProcessMachineContext)
+	process := processContext.Process
+
+	config, err := process.GetConfig()
+	if err != nil {
+		return machine.NoopEvent, err
+	}
+
+	serializedProcess := process.Serialize()
+
+	switch config.Autorestart {
+	case AutorestartOn:
+		processContext.Starttries++
+		if processContext.Starttries == config.Startretries {
+			log.Printf(
+				"Fatal: could not start process '%s' of program '%s' (%d tries)",
+				serializedProcess.ID,
+				config.Name,
+				processContext.Starttries,
+			)
+			return ProcessEventFatal, nil
+		}
+		log.Printf(
+			"Trying to restart process '%s' of program '%s'...",
+			serializedProcess.ID,
+			config.Name,
+		)
+		return ProcessEventStart, nil
+	case AutorestartUnexpected:
+		exitcode := process.GetCmd().ProcessState.ExitCode()
+		for _, allowedExitcode := range config.Exitcodes {
+			if exitcode == allowedExitcode {
+				return machine.NoopEvent, nil
+			}
+		}
+		processContext.Starttries++
+		if processContext.Starttries == config.Startretries {
+			log.Printf(
+				"Fatal: could not start process '%s' of program '%s' (%d tries)",
+				serializedProcess.ID,
+				config.Name,
+				processContext.Starttries,
+			)
+			return ProcessEventFatal, nil
+		}
+		log.Printf(
+			"Trying to restart process '%s' of program '%s'...",
+			serializedProcess.ID,
+			config.Name,
+		)
+		return ProcessEventStart, nil
+	default:
+		return machine.NoopEvent, nil
+	}
+}
+
+func ProcessRunningAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
+	processContext := context.(*ProcessMachineContext)
+	processContext.Starttries = 0
+
+	return machine.NoopEvent, nil
 }

--- a/cmd/taskmasterd/process_machine.go
+++ b/cmd/taskmasterd/process_machine.go
@@ -24,7 +24,7 @@ const (
 )
 
 type ProcessMachineContext struct {
-	Process    *Process
+	Process    Processer
 	Starttries int
 }
 

--- a/cmd/taskmasterd/task.go
+++ b/cmd/taskmasterd/task.go
@@ -6,7 +6,15 @@ var (
 	ErrChannelClosed = errors.New("channel has been closed")
 )
 
+type Tasker interface {
+	GetAction() TaskAction
+}
+
 type TaskAction string
+
+func (task TaskAction) GetAction() TaskAction {
+	return task
+}
 
 const (
 	TaskmasterdTaskActionGet    TaskAction = "TASKMASTERD_GET"
@@ -28,16 +36,24 @@ const (
 	ProgramTaskActionSetConfig      TaskAction = "PROGRAM_SET_CONFIG"
 	ProgramTaskActionGetConfig      TaskAction = "PROGRAM_GET_CONFIG"
 
-	ProcessTaskActionGet     TaskAction = "PROCESS_GET"
-	ProcessTaskActionStart   TaskAction = "PROCESS_START"
-	ProcessTaskActionStop    TaskAction = "PROCESS_STOP"
-	ProcessTaskActionRestart TaskAction = "PROCESS_RESTART"
-	ProcessTaskActionKill    TaskAction = "PROCESS_KILL"
-)
+	ProcessTaskActionGetContext                  TaskAction = "PROCESS_GET_CONTEXT"
+	ProcessTaskActionSerialize                   TaskAction = "PROCESS_SERIALIZE"
+	ProcessTaskActionCreateNewDeadChannel        TaskAction = "PROCESS_CREATE_NEW_DEAD_CHANNEL"
+	ProcessTaskActionGetProgramConfig            TaskAction = "PROCESS_GET_PROGRAM_CONFIG"
+	ProcessTaskActionGetCmd                      TaskAction = "PROCESS_GET_CMD"
+	ProcessTaskActionGetDeadChannel              TaskAction = "PROCESS_GET_DEAD_CHANNEL"
+	ProcessTaskActionGetStateMachineCurrentState TaskAction = "PROCESS_GET_STATE_MACHINE_CURRENT_STATE"
+	ProcessTaskActionSetCmd                      TaskAction = "PROCESS_SET_CMD"
+	ProcessTaskActionSetStdoutStderrCloser       TaskAction = "PROCESS_SET_STDOUT_STDERR_CLOSER"
+	ProcessTaskActionCloseFileDescriptors        TaskAction = "PROCESS_CLOSE_FILE_DESCRIPTORS"
+	ProcessTaskActionStart                       TaskAction = "PROCESS_START"
+	ProcessTaskActionStop                        TaskAction = "PROCESS_STOP"
+	ProcessTaskActionRestart                     TaskAction = "PROCESS_RESTART"
+	ProcessTaskActionKill                        TaskAction = "PROCESS_KILL"
 
-type Tasker interface {
-	GetAction() TaskAction
-}
+	ProcessTaskActionStartChronometer TaskAction = "PROCESS_START_CHRONOMETER"
+	ProcessTaskActionStopChronometer  TaskAction = "PROCESS_STOP_CHRONOMETER"
+)
 
 type TaskBase struct {
 	Action TaskAction
@@ -111,4 +127,16 @@ type ProcessTask struct {
 	TaskBase
 
 	ProcessID string
+}
+
+type ProcessInternalTaskWithResponse struct {
+	TaskBase
+
+	ResponseChan chan interface{}
+}
+
+type ProcessInternalTaskWithPayload struct {
+	TaskBase
+
+	Payload interface{}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -197,7 +197,7 @@ func ParseCommand(cmd string) (ParsedCommand, error) {
 	}, nil
 }
 
-func parserStateWhitespaceAction(context machine.Context) (machine.EventType, error) {
+func parserStateWhitespaceAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
 	ctx := context.(*parserContext)
 
 	if ctx.CurrentChunk == "" {
@@ -210,7 +210,7 @@ func parserStateWhitespaceAction(context machine.Context) (machine.EventType, er
 	return machine.NoopEvent, nil
 }
 
-func parserStateInWordAction(context machine.Context) (machine.EventType, error) {
+func parserStateInWordAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
 	ctx := context.(*parserContext)
 
 	ctx.CurrentChunk += string(*ctx.CurrentChar)
@@ -218,7 +218,7 @@ func parserStateInWordAction(context machine.Context) (machine.EventType, error)
 	return machine.NoopEvent, nil
 }
 
-func parserStateInWordDoubleQuotedAction(context machine.Context) (machine.EventType, error) {
+func parserStateInWordDoubleQuotedAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
 	ctx := context.(*parserContext)
 
 	if *ctx.CurrentChar == '"' {
@@ -230,7 +230,7 @@ func parserStateInWordDoubleQuotedAction(context machine.Context) (machine.Event
 	return machine.NoopEvent, nil
 }
 
-func parserStateInWordSingleQuotedAction(context machine.Context) (machine.EventType, error) {
+func parserStateInWordSingleQuotedAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
 	ctx := context.(*parserContext)
 
 	if *ctx.CurrentChar == '\'' {
@@ -242,7 +242,7 @@ func parserStateInWordSingleQuotedAction(context machine.Context) (machine.Event
 	return machine.NoopEvent, nil
 }
 
-func parserStateEndAction(context machine.Context) (machine.EventType, error) {
+func parserStateEndAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
 	ctx := context.(*parserContext)
 
 	if ctx.CurrentChunk == "" {


### PR DESCRIPTION
To prevent data races we must ensure read and write operations occur on the same goroutine, if there is a single write operation.
For that we updated the monitor function as follows:
- _external_ operations, such as _starting,_ _stopping_, _restarting_ or _killing_ functions are run in a separate goroutine so that the state machine actions can send messages to the _internal_ task queue without blocking everything
- _internal_ operations are read or write operations on _Process_ structure fields and are processed fully sequentially

Restart operation is now working and atomic: we stop the current process, we wait for it to be actually stopped and then we start it again.
_Note_: We had to move where we close the `deadCh` channel. If we close it before the state machine reaches a new state, we will try to send a `START` event to it and it will not perform the action. We must be sure that the state machine either reached `Stopped` or `Killed` state before closing `deadCh`

We use an interface `Processer` to hide the implementation details to the callers so that they can just rely on a well defined API and can't even access to private properties.

Now State Machine actions take the current machine as the first argument so we don't any more have to get it from `context.Process.Machine`.