### PR TITLE
Fix infinite restarts after backoff

### DIFF
--- a/cmd/taskmasterd/process_actions.go
+++ b/cmd/taskmasterd/process_actions.go
@@ -208,7 +208,7 @@ func ProcessBackoffAction(stateMachine *machine.Machine, context machine.Context
 	switch config.Autorestart {
 	case AutorestartOn:
 		processContext.Starttries++
-		if processContext.Starttries == config.Startretries {
+		if processContext.Starttries >= config.Startretries {
 			log.Printf(
 				"Fatal: could not start process '%s' of program '%s' (%d tries)",
 				serializedProcess.ID,
@@ -231,7 +231,7 @@ func ProcessBackoffAction(stateMachine *machine.Machine, context machine.Context
 			}
 		}
 		processContext.Starttries++
-		if processContext.Starttries == config.Startretries {
+		if processContext.Starttries >= config.Startretries {
 			log.Printf(
 				"Fatal: could not start process '%s' of program '%s' (%d tries)",
 				serializedProcess.ID,
@@ -251,7 +251,7 @@ func ProcessBackoffAction(stateMachine *machine.Machine, context machine.Context
 	}
 }
 
-func ProcessRunningAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
+func ProcessResetStarttriesAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
 	processContext := context.(*ProcessMachineContext)
 	processContext.Starttries = 0
 

--- a/cmd/taskmasterd/process_machine.go
+++ b/cmd/taskmasterd/process_machine.go
@@ -70,7 +70,7 @@ func NewProcessMachine(process *Process) *machine.Machine {
 
 			ProcessStateRunning: machine.StateNode{
 				Actions: []machine.Action{
-					ProcessRunningAction,
+					ProcessResetStarttriesAction,
 				},
 
 				On: machine.Events{
@@ -82,6 +82,7 @@ func NewProcessMachine(process *Process) *machine.Machine {
 			ProcessStateStopping: machine.StateNode{
 				Actions: []machine.Action{
 					ProcessStopAction,
+					ProcessResetStarttriesAction,
 				},
 
 				On: machine.Events{
@@ -96,6 +97,10 @@ func NewProcessMachine(process *Process) *machine.Machine {
 			},
 
 			ProcessStateFatal: machine.StateNode{
+				Actions: []machine.Action{
+					ProcessResetStarttriesAction,
+				},
+
 				On: machine.Events{
 					ProcessEventStart: ProcessStateStarting,
 				},

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"errors"
+	"log"
 	"strconv"
 	"sync"
 )
@@ -117,6 +118,8 @@ type Machine struct {
 
 	StateNodes StateNodes
 
+	Debug bool
+
 	lock sync.Mutex
 }
 
@@ -152,6 +155,9 @@ func (machine *Machine) getNextState(event EventType) (StateType, error) {
 			Err: ErrInvalidTransitionInvalidCurrentState,
 		}
 	}
+	if machine.Debug {
+		log.Println("state machine: current state:", machine.current)
+	}
 
 	if currentState.On == nil {
 		return NoopState, &ErrInvalidTransition{
@@ -164,6 +170,9 @@ func (machine *Machine) getNextState(event EventType) (StateType, error) {
 		return NoopState, &ErrInvalidTransition{
 			Err: ErrInvalidTransitionNotImplemented,
 		}
+	}
+	if machine.Debug {
+		log.Println("state machine: next state:", nextState)
 	}
 
 	return nextState, nil


### PR DESCRIPTION
Reset `Starttries` counter when reaching `running`, `stopping` and `fatal` states.
Like that `Starttries` is always equal to `0` when we start the process again.

Closes #50 