### PR TITLE
Reach backoff state if the command could not be executed

### DIFF
--- a/cmd/taskmasterd/process_actions.go
+++ b/cmd/taskmasterd/process_actions.go
@@ -104,12 +104,7 @@ func ProcessStartAction(stateMachine *machine.Machine, context machine.Context) 
 
 		ResetUmask()
 
-		return ProcessEventFatal, &ErrProcessAction{
-			ID: serializedProcess.ID,
-			Err: &ErrProcessStarting{
-				Err: err,
-			},
-		}
+		return ProcessEventStopped, nil
 	}
 	ResetUmask()
 

--- a/cmd/taskmasterd/process_machine.go
+++ b/cmd/taskmasterd/process_machine.go
@@ -14,12 +14,11 @@ const (
 )
 
 const (
-	ProcessEventStart          machine.EventType = "start"
-	ProcessEventStarted        machine.EventType = "started"
-	ProcessEventStop           machine.EventType = "stop"
-	ProcessEventExitedTooEarly machine.EventType = "exited-too-early"
-	ProcessEventStopped        machine.EventType = "stopped"
-	ProcessEventFatal          machine.EventType = "fatal"
+	ProcessEventStart   machine.EventType = "start"
+	ProcessEventStarted machine.EventType = "started"
+	ProcessEventStop    machine.EventType = "stop"
+	ProcessEventStopped machine.EventType = "stopped"
+	ProcessEventFatal   machine.EventType = "fatal"
 )
 
 type ProcessMachineContext struct {

--- a/taskmaster.yaml
+++ b/taskmaster.yaml
@@ -54,3 +54,10 @@ programs:
     env:
       STARTED_BY: taskmaster
       ANSWER: 42
+  unknown-command:
+    cmd: "yolo"
+    autostart: true
+    autorestart: true
+    startretries: 3
+    starttime: 10
+    stoptime: 10

--- a/tests/launch-tests.sh
+++ b/tests/launch-tests.sh
@@ -6,12 +6,16 @@ ROOT_PATH=$PWD
 setUp() {
     cd $ROOT_PATH/scenarios
     git restore .
+
+    true
 }
 
 tearDown() {
     echo $PWD
     pkill taskmasterd
     git restore .
+
+    true
 }
 
 testInfinite() {
@@ -34,6 +38,15 @@ testHotReloadTotalNewConfig() {
 
 testHotReloadUpdateProgramConfig() {
     cd hot-reload-update-program-config
+    rm -f taskmasterd.log
+
+    ./test.sh
+
+    assertTrue $?
+}
+
+testHotReloadUpdateProgramConfig() {
+    cd not-found-command
     rm -f taskmasterd.log
 
     ./test.sh

--- a/tests/scenarios/not-found-command/not-found-command.strest.yml
+++ b/tests/scenarios/not-found-command/not-found-command.strest.yml
@@ -1,0 +1,27 @@
+requests:
+  start-process:
+    request:
+      url: http://localhost:8080/start
+      method: POST
+      postData:
+        mimeType: application/json
+        text:
+          program_id: unknown-command
+    validate:
+      - jsonpath: status
+        expect: 200
+  running-status:
+    request:
+      url: http://localhost:8080/status
+      method: GET
+    delay: 1000
+    maxRetries: 2
+    validate:
+      - jsonpath: content.result.programs.length
+        expect: 1
+      - jsonpath: content.result.programs[0].id
+        expect: unknown-command
+      - jsonpath: content.result.programs[0].state
+        expect: FATAL
+      - jsonpath: content.result.programs[0].processes[0].state
+        expect: FATAL

--- a/tests/scenarios/not-found-command/taskmaster.yaml
+++ b/tests/scenarios/not-found-command/taskmaster.yaml
@@ -1,0 +1,8 @@
+programs:
+  unknown-command:
+    cmd: "yolo"
+    autostart: false
+    autorestart: true
+    startretries: 3
+    starttime: 10
+    stoptime: 10

--- a/tests/scenarios/not-found-command/test.sh
+++ b/tests/scenarios/not-found-command/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+taskmasterd 2> /dev/null
+
+strest not-found-command.strest.yml


### PR DESCRIPTION
If we encounter an error while trying to launch a process, for instance if the command could not be executed, we `transition` from `starting` state to backoff state and let the system try to relaunch the program.

Closes #48 