### PR TITLE
Set API response Content-Type header to JSON

### DIFF
--- a/cmd/taskmasterd/http.go
+++ b/cmd/taskmasterd/http.go
@@ -343,6 +343,7 @@ func httpHandleEndpoint(taskmasterd *Taskmasterd, callback HttpEndpointFunc) Htt
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "*")
 		w.Header().Set("Access-Control-Allow-Headers", "*")
+		w.Header().Set("Content-Type", "application/json")
 		if r.Method != "OPTIONS" {
 			callback(taskmasterd, w, r)
 		}


### PR DESCRIPTION
Thanks to this header every client requesting the API will now how to parse the response (as well as the browsers).