### PR TITLE
Add route to create program from json

### DIFF
--- a/cmd/taskmasterd/config.go
+++ b/cmd/taskmasterd/config.go
@@ -34,13 +34,13 @@ func configGetFileReader(path string) (io.ReadCloser, error) {
 	return os.Open(path)
 }
 
-func configParse(r io.Reader) (ProgramsConfigurations, error) {
+func configParse(r io.Reader) (ProgramsYaml, ProgramsConfigurations, error) {
 	parsedPrograms, err := yamlParse(r)
 	if err != nil {
-		return nil, err
+		return ProgramsYaml{}, nil, err
 	}
 
 	programsConfigurations, err := parsedPrograms.Validate()
 
-	return programsConfigurations, err
+	return parsedPrograms, programsConfigurations, err
 }

--- a/cmd/taskmasterd/main.go
+++ b/cmd/taskmasterd/main.go
@@ -27,7 +27,7 @@ func main() {
 		log.Panic(err)
 	}
 
-	programsConfigurations, err := configParse(configReader)
+	programsYamlConfiguration, programsConfigurations, err := configParse(configReader)
 	if err != nil {
 		log.Fatalf("Error parsing configuration file: %s: %v\n", args.ConfigPathArg, err)
 		os.Exit(1)
@@ -46,9 +46,10 @@ func main() {
 	context, cancel := context.WithCancel(context.Background())
 
 	taskmasterd := NewTaskmasterd(NewTaskmasterdArgs{
-		Args:    args,
-		Context: context,
-		Cancel:  cancel,
+		Args:                  args,
+		ProgramsConfiguration: programsYamlConfiguration,
+		Context:               context,
+		Cancel:                cancel,
 	})
 	taskmasterd.SignalsSetup()
 	go taskmasterd.LoadProgramsConfigurations(programsConfigurations)

--- a/cmd/taskmasterd/program.go
+++ b/cmd/taskmasterd/program.go
@@ -252,8 +252,6 @@ func (program *Program) setConfig(task Tasker) error {
 		}
 	}
 
-	// TODO: reload the configuration of all the others processes if necessary
-
 	return nil
 }
 

--- a/cmd/taskmasterd/task.go
+++ b/cmd/taskmasterd/task.go
@@ -1,6 +1,9 @@
 package main
 
-import "errors"
+import (
+	"errors"
+	"io"
+)
 
 var (
 	ErrChannelClosed = errors.New("channel has been closed")
@@ -17,10 +20,16 @@ func (task TaskAction) GetAction() TaskAction {
 }
 
 const (
-	TaskmasterdTaskActionGet    TaskAction = "TASKMASTERD_GET"
-	TaskmasterdTaskActionGetAll TaskAction = "TASKMASTERD_GET_ALL"
-	TaskmasterdTaskActionAdd    TaskAction = "TASKMASTERD_ADD"
-	TaskmasterdTaskActionRemove TaskAction = "TASKMASTERD_REMOVE"
+	TaskmasterdTaskActionGet                                       TaskAction = "TASKMASTERD_GET"
+	TaskmasterdTaskActionGetAll                                    TaskAction = "TASKMASTERD_GET_ALL"
+	TaskmasterdTaskActionAdd                                       TaskAction = "TASKMASTERD_ADD"
+	TaskmasterdTaskActionRemove                                    TaskAction = "TASKMASTERD_REMOVE"
+	TaskmasterdTaskActionAddProgramConfiguration                   TaskAction = "TASKMASTERD_ADD_PROGRAM_CONFIGURATION"
+	TaskmasterdTaskActionReplaceProgramsConfigurations             TaskAction = "TASKMASTERD_REPLACE_PROGRAMS_CONFIGURATIONS"
+	TaskmasterdTaskActionRefreshConfigurationFromConfigurationFile TaskAction = "TASKMASTERD_REFRESH_CONFIGURATION_FROM_CONFIGURATION_FILE"
+	TaskmasterdTaskActionRefreshConfigurationFromReader            TaskAction = "TASKMASTERD_REFRESH_CONFIGURATION_FROM_READER"
+	TaskmasterdTaskActionGetProgramsConfigurations                 TaskAction = "TASKMASTERD_GET_PROGRAMS_CONFIGURATIONS"
+	TaskmasterdTaskActionPersistProgramsToDisk                     TaskAction = "TASKMASTERD_PERSIST_PROGRAMS_TO_DISK"
 
 	ProgramTaskActionGet            TaskAction = "PROGRAM_GET"
 	ProgramTaskActionGetAll         TaskAction = "PROGRAM_GET_ALL"
@@ -87,6 +96,32 @@ type TaskmasterdTaskAdd struct {
 	TaskBase
 
 	Program Program
+}
+
+type TaskmasterdTaskAddProgramConfiguration struct {
+	TaskBase
+
+	ProgramConfiguration ProgramYaml
+	ErrorChan            chan<- error
+}
+
+type TaskmasterdTaskReplaceProgramsConfigurations struct {
+	TaskBase
+
+	ProgramsConfigurations ProgramsYaml
+}
+
+type TaskmasterdTaskGetProgramsConfigurations struct {
+	TaskBase
+
+	ProgramsConfigurationsChan chan<- ProgramsYaml
+}
+
+type TaskmasterdTaskRefreshConfigurationFromReader struct {
+	TaskBase
+
+	Reader    io.Reader
+	ErrorChan chan<- error
 }
 
 type ProgramTask struct {

--- a/cmd/taskmasterd/yaml.go
+++ b/cmd/taskmasterd/yaml.go
@@ -140,21 +140,21 @@ func (config *ProgramConfiguration) CreateCmdStderr(processID string) (io.WriteC
 }
 
 type ProgramYaml struct {
-	Name         string           `json:"name"`
-	Cmd          *string          `yaml:"cmd,omitempty" json:"cmd,omitempty"`
-	Numprocs     *int             `yaml:"numprocs,omitempty" json:"numprocs,omitempty"`
-	Umask        *string          `yaml:"umask,omitempty" json:"umask,omitempty"`
-	Workingdir   *string          `yaml:"workingdir,omitempty" json:"workingdir,omitempty"`
-	Autostart    *bool            `yaml:"autostart,omitempty" json:"autostart,omitempty"`
-	Autorestart  *AutorestartType `yaml:"autorestart,omitempty" json:"autorestart,omitempty"`
-	Exitcodes    interface{}      `yaml:"exitcodes,omitempty" json:"exitcodes,omitempty"`
-	Startretries *int             `yaml:"startretries,omitempty" json:"startretries,omitempty"`
-	Starttime    *int             `yaml:"starttime,omitempty" json:"starttime,omitempty"`
-	Stopsignal   *StopSignal      `yaml:"stopsignal,omitempty" json:"stopsignal,omitempty"`
-	Stoptime     *int             `yaml:"stoptime,omitempty" json:"stoptime,omitempty"`
-	Stdout       *string          `yaml:"stdout,omitempty" json:"stdout,omitempty"`
-	Stderr       *string          `yaml:"stderr,omitempty" json:"stderr,omitempty"`
-	Env          map[string]string
+	Name         *string           `yaml:"-" json:"name,omitempty"`
+	Cmd          *string           `yaml:"cmd,omitempty" json:"cmd,omitempty"`
+	Numprocs     *int              `yaml:"numprocs,omitempty" json:"numprocs,omitempty"`
+	Umask        *string           `yaml:"umask,omitempty" json:"umask,omitempty"`
+	Workingdir   *string           `yaml:"workingdir,omitempty" json:"workingdir,omitempty"`
+	Autostart    *bool             `yaml:"autostart,omitempty" json:"autostart,omitempty"`
+	Autorestart  *AutorestartType  `yaml:"autorestart,omitempty" json:"autorestart,omitempty"`
+	Exitcodes    interface{}       `yaml:"exitcodes,omitempty" json:"exitcodes,omitempty"`
+	Startretries *int              `yaml:"startretries,omitempty" json:"startretries,omitempty"`
+	Starttime    *int              `yaml:"starttime,omitempty" json:"starttime,omitempty"`
+	Stopsignal   *StopSignal       `yaml:"stopsignal,omitempty" json:"stopsignal,omitempty"`
+	Stoptime     *int              `yaml:"stoptime,omitempty" json:"stoptime,omitempty"`
+	Stdout       *string           `yaml:"stdout,omitempty" json:"stdout,omitempty"`
+	Stderr       *string           `yaml:"stderr,omitempty" json:"stderr,omitempty"`
+	Env          map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
 }
 
 func (program *ProgramYaml) NormalizedExitcodes() []int {
@@ -185,7 +185,7 @@ func (program *ProgramYaml) Validate(args ProgramYamlValidateArgs) (ProgramConfi
 	}
 
 	if args.PickProgramName {
-		programName := strings.TrimSpace(program.Name)
+		programName := strings.TrimSpace(*program.Name)
 
 		if programName == "" {
 			return config, &ErrProgramsYamlValidation{

--- a/taskmaster.yaml
+++ b/taskmaster.yaml
@@ -1,31 +1,13 @@
 programs:
-  infinite:
-    cmd: "./tests/bin_infinite"
-    numprocs: 3
-    umask: 022
-    workingdir: /tmp
-    autostart: true
-    autorestart: true
-    exitcodes:
-      - 2
-    startretries: 3
-    starttime: 10
-    stopsignal: QUIT
-    stoptime: 10
-    stdout: /tmp/nginx.stdout
-    stderr: /tmp/nginx.stderr
-    env:
-      STARTED_BY: taskmaster
-      ANSWER: 42
   backoff:
-    cmd: "./tests/bin_backoff"
+    cmd: ./tests/bin_backoff
     numprocs: 1
-    umask: 022
+    umask: "022"
     workingdir: /tmp
     autostart: true
-    autorestart: true
+    autorestart: "true"
     exitcodes:
-      - 2
+    - 2
     startretries: 3
     starttime: 10
     stopsignal: QUIT
@@ -33,18 +15,18 @@ programs:
     stdout: /tmp/nginx.stdout
     stderr: /tmp/nginx.stderr
     env:
+      ANSWER: "42"
       STARTED_BY: taskmaster
-      ANSWER: 42
   exited:
-    cmd: "./tests/bin_exited"
+    cmd: ./tests/bin_exited
     numprocs: 1
-    umask: 022
+    umask: "022"
     workingdir: /tmp
     autostart: true
     autorestart: unexpected
     exitcodes:
-      - 0
-      - 2
+    - 0
+    - 2
     startretries: 3
     starttime: 10
     stopsignal: QUIT
@@ -52,12 +34,32 @@ programs:
     stdout: /tmp/nginx.stdout
     stderr: /tmp/nginx.stderr
     env:
+      ANSWER: "42"
       STARTED_BY: taskmaster
-      ANSWER: 42
-  unknown-command:
-    cmd: "yolo"
+  exited yeahhhh:
+    cmd: ./tests/bin_exited
+  infinite:
+    cmd: ./tests/bin_infinite
+    numprocs: 3
+    umask: "022"
+    workingdir: /tmp
     autostart: true
-    autorestart: true
+    autorestart: "true"
+    exitcodes:
+    - 2
+    startretries: 3
+    starttime: 10
+    stopsignal: QUIT
+    stoptime: 10
+    stdout: /tmp/nginx.stdout
+    stderr: /tmp/nginx.stderr
+    env:
+      ANSWER: "42"
+      STARTED_BY: taskmaster
+  unknown-command:
+    cmd: yolo
+    autostart: true
+    autorestart: "true"
     startretries: 3
     starttime: 10
     stoptime: 10

--- a/tests/launch-tests.sh
+++ b/tests/launch-tests.sh
@@ -5,6 +5,7 @@ ROOT_PATH=$PWD
 
 setUp() {
     cd $ROOT_PATH/scenarios
+    pkill taskmasterd
     git restore .
 
     true
@@ -45,7 +46,7 @@ testHotReloadUpdateProgramConfig() {
     assertTrue $?
 }
 
-testHotReloadUpdateProgramConfig() {
+testNotFoundCommand() {
     cd not-found-command
     rm -f taskmasterd.log
 

--- a/tests/launch-tests.sh
+++ b/tests/launch-tests.sh
@@ -6,7 +6,6 @@ ROOT_PATH=$PWD
 setUp() {
     cd $ROOT_PATH/scenarios
     pkill taskmasterd
-    git restore .
 
     true
 }
@@ -14,6 +13,7 @@ setUp() {
 tearDown() {
     echo $PWD
     pkill taskmasterd
+
     git restore .
 
     true
@@ -26,6 +26,10 @@ testInfinite() {
     ./test.sh
 
     assertTrue $?
+
+    git diff --exit-code . > /dev/null
+
+    assertTrue "Files should have not been modified but were" $?
 }
 
 testHotReloadTotalNewConfig() {
@@ -35,6 +39,10 @@ testHotReloadTotalNewConfig() {
     ./test.sh
 
     assertTrue $?
+
+    git diff --exit-code . > /dev/null
+
+    assertFalse "Files should have been modified but were not" $?
 }
 
 testHotReloadUpdateProgramConfig() {
@@ -44,6 +52,10 @@ testHotReloadUpdateProgramConfig() {
     ./test.sh
 
     assertTrue $?
+
+    git diff --exit-code . > /dev/null
+
+    assertFalse "Files should have been modified but were not" $?
 }
 
 testNotFoundCommand() {
@@ -53,6 +65,11 @@ testNotFoundCommand() {
     ./test.sh
 
     assertTrue $?
+
+    git diff --exit-code . > /dev/null
+
+    assertTrue "Files should have not been modified but were" $?
+
 }
 
 testCreateProgram() {
@@ -62,6 +79,10 @@ testCreateProgram() {
     ./test.sh
 
     assertTrue $?
+
+    git diff --exit-code . > /dev/null
+
+    assertFalse "Files should have been modified but were not" $?
 }
 
 . ./vendor/shunit2/shunit2

--- a/tests/launch-tests.sh
+++ b/tests/launch-tests.sh
@@ -55,4 +55,13 @@ testNotFoundCommand() {
     assertTrue $?
 }
 
+testCreateProgram() {
+    cd create-program
+    rm -f taskmasterd.log
+
+    ./test.sh
+
+    assertTrue $?
+}
+
 . ./vendor/shunit2/shunit2

--- a/tests/scenarios/create-program/create-program.strest.yml
+++ b/tests/scenarios/create-program/create-program.strest.yml
@@ -34,14 +34,14 @@ requests:
     maxRetries: 2
     validate:
       - jsonpath: content.result.data
-        expect: >-
+        expect: |
           programs:
-            infinite:
-              cmd: "bin_infinite"
-              autostart: true
-              starttime: 1
             exited yeahhhh:
               cmd: bin_exited
+            infinite:
+              cmd: bin_infinite
+              autostart: true
+              starttime: 1
   newly-created-program-status:
     request:
       url: http://localhost:8080/status

--- a/tests/scenarios/create-program/create-program.strest.yml
+++ b/tests/scenarios/create-program/create-program.strest.yml
@@ -1,0 +1,64 @@
+requests:
+  beginning-status:
+    request:
+      url: http://localhost:8080/status
+      method: GET
+    delay: 1000
+    maxRetries: 2
+    validate:
+      - jsonpath: content.result.programs.length
+        expect: 1
+      - jsonpath: content.result.programs[0].id
+        expect: infinite
+      - jsonpath: content.result.programs[0].state
+        expect: RUNNING
+      - jsonpath: content.result.programs[0].processes[0].state
+        expect: RUNNING
+  create-command:
+    request:
+      url: http://localhost:8080/programs
+      method: POST
+      postData:
+        mimeType: application/json
+        text:
+          name: "exited yeahhhh    "
+          cmd: "bin_exited"
+    validate:
+      - jsonpath: status
+        expect: 200
+  assure-config-has-been-written-to-the-disk:
+    request:
+      url: http://localhost:8080/configuration
+      method: GET
+    delay: 500
+    maxRetries: 2
+    validate:
+      - jsonpath: content.result.data
+        expect: >-
+          programs:
+            infinite:
+              cmd: "bin_infinite"
+              autostart: true
+              starttime: 1
+            exited yeahhhh:
+              cmd: bin_exited
+  newly-created-program-status:
+    request:
+      url: http://localhost:8080/status
+      method: GET
+    delay: 15_000
+    validate:
+      - jsonpath: content.result.programs.length
+        expect: 2
+      - jsonpath: content.result.programs[0].id
+        expect: exited yeahhhh
+      - jsonpath: content.result.programs[0].state
+        expect: EXITED
+      - jsonpath: content.result.programs[0].processes[0].state
+        expect: EXITED
+      - jsonpath: content.result.programs[1].id
+        expect: infinite
+      - jsonpath: content.result.programs[1].state
+        expect: RUNNING
+      - jsonpath: content.result.programs[1].processes[0].state
+        expect: RUNNING

--- a/tests/scenarios/create-program/taskmaster.yaml
+++ b/tests/scenarios/create-program/taskmaster.yaml
@@ -1,0 +1,5 @@
+programs:
+  infinite:
+    cmd: "bin_infinite"
+    autostart: true
+    starttime: 1

--- a/tests/scenarios/create-program/test.sh
+++ b/tests/scenarios/create-program/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+taskmasterd 2> /dev/null
+
+strest create-program.strest.yml


### PR DESCRIPTION
We added a route to create a program by sending its configuration through JSON.
The program is automatically created and loaded. If it's configured to autostart, it will.

We centralized how we dealt with the configuration file.
Now all the operations are made sequentially and we read from the configuration only when we explicitly have to, that is:
- at start
- when receiving a `SIGHUP` signal
When the user wants to know what the actual configuration file is, we return a YAML version of the programs we have in memory and that reflects which programs are currently and actually managed by the Taskmasterd process.

The code is also cleaner as we reduced the duplication of cryptic lines of code, such as the configuration file content overwriting.

Of course we added E2E tests to test the creation of a program through JSON.

We also improved previous tests to assert that files were changed or not during the test. It's useful to assert that the configuration file has been persisted to the disk when it had to.

Closes #54 