### PR TITLE
Return an empty PID of process not currently running

### DIFF
--- a/cmd/taskmasterd/http.go
+++ b/cmd/taskmasterd/http.go
@@ -88,9 +88,13 @@ func httpEndpointStatus(taskmasterd *Taskmasterd, w http.ResponseWriter, r *http
 					State:         GetProgramState(processes),
 				}
 				for _, process := range processes {
+					processState := process.GetStateMachineCurrentState()
+
 					pid := 0
-					if cmd := process.GetCmd(); cmd != nil && cmd.Process != nil {
-						pid = cmd.Process.Pid
+					if processState == ProcessStateRunning {
+						if cmd := process.GetCmd(); cmd != nil && cmd.Process != nil {
+							pid = cmd.Process.Pid
+						}
 					}
 
 					serializedProcess := process.Serialize()
@@ -98,7 +102,7 @@ func httpEndpointStatus(taskmasterd *Taskmasterd, w http.ResponseWriter, r *http
 					httpProcess := HttpProcess{
 						ID:    serializedProcess.ID,
 						Pid:   pid,
-						State: process.GetStateMachineCurrentState(),
+						State: processState,
 
 						StartedAt: serializedProcess.StartedAt,
 						EndedAt:   serializedProcess.EndedAt,

--- a/tests/scenarios/hot-reload-total-new-config/hot-reload-total-new-config.strest.yml
+++ b/tests/scenarios/hot-reload-total-new-config/hot-reload-total-new-config.strest.yml
@@ -25,6 +25,8 @@ requests:
         expect: RUNNING
       - jsonpath: content.result.programs[0].processes[0].state
         expect: RUNNING
+      - jsonpath: content.result.programs[0].processes[0].pid
+        regex: ^[1-9]
   hot-reload:
     request:
       url: http://localhost:8080/configuration
@@ -54,3 +56,5 @@ requests:
         expect: RUNNING
       - jsonpath: content.result.programs[0].processes[0].state
         expect: RUNNING
+      - jsonpath: content.result.programs[0].processes[0].pid
+        regex: ^[1-9]

--- a/tests/scenarios/hot-reload-update-program-config/hot-reload-update-program-config.strest.yml
+++ b/tests/scenarios/hot-reload-update-program-config/hot-reload-update-program-config.strest.yml
@@ -27,6 +27,8 @@ requests:
         expect: 1
       - jsonpath: content.result.programs[0].processes[0].state
         expect: RUNNING
+      - jsonpath: content.result.programs[0].processes[0].pid
+        regex: ^[1-9]
   hot-reload-increment-numprocs:
     request:
       url: http://localhost:8080/configuration
@@ -58,10 +60,16 @@ requests:
         expect: 3
       - jsonpath: content.result.programs[0].processes[0].state
         expect: RUNNING
+      - jsonpath: content.result.programs[0].processes[0].pid
+        regex: ^[1-9]
       - jsonpath: content.result.programs[0].processes[1].state
         expect: RUNNING
+      - jsonpath: content.result.programs[0].processes[1].pid
+        regex: ^[1-9]
       - jsonpath: content.result.programs[0].processes[2].state
         expect: RUNNING
+      - jsonpath: content.result.programs[0].processes[2].pid
+        regex: ^[1-9]
   hot-reload-decrement-numprocs:
     request:
       url: http://localhost:8080/configuration
@@ -93,5 +101,9 @@ requests:
         expect: 2
       - jsonpath: content.result.programs[0].processes[0].state
         expect: RUNNING
+      - jsonpath: content.result.programs[0].processes[0].pid
+        regex: ^[1-9]
       - jsonpath: content.result.programs[0].processes[1].state
         expect: RUNNING
+      - jsonpath: content.result.programs[0].processes[1].pid
+        regex: ^[1-9]

--- a/tests/scenarios/infinite/infinite.strest.yml
+++ b/tests/scenarios/infinite/infinite.strest.yml
@@ -25,6 +25,8 @@ requests:
         expect: RUNNING
       - jsonpath: content.result.programs[0].processes[0].state
         expect: RUNNING
+      - jsonpath: content.result.programs[0].processes[0].pid
+        regex: ^[1-9]
   stop-immortal-with-sigterm:
     request:
       url: http://localhost:8080/stop
@@ -49,6 +51,8 @@ requests:
         expect: STOPPING
       - jsonpath: content.result.programs[0].processes[0].state
         expect: STOPPING
+      - jsonpath: content.result.programs[0].processes[0].pid
+        regex: ^0
   still-stopping-after-2-seconds:
     request:
       url: http://localhost:8080/status
@@ -63,6 +67,8 @@ requests:
         expect: STOPPING
       - jsonpath: content.result.programs[0].processes[0].state
         expect: STOPPING
+      - jsonpath: content.result.programs[0].processes[0].pid
+        regex: ^0
   still-stopping-after-5-seconds:
     request:
       url: http://localhost:8080/status
@@ -77,6 +83,8 @@ requests:
         expect: STOPPING
       - jsonpath: content.result.programs[0].processes[0].state
         expect: STOPPING
+      - jsonpath: content.result.programs[0].processes[0].pid
+        regex: ^0
   stopped-after-11-seconds:
     request:
       url: http://localhost:8080/status
@@ -91,3 +99,5 @@ requests:
         expect: STOPPED
       - jsonpath: content.result.programs[0].processes[0].state
         expect: STOPPED
+      - jsonpath: content.result.programs[0].processes[0].pid
+        regex: ^0

--- a/tests/scenarios/not-found-command/not-found-command.strest.yml
+++ b/tests/scenarios/not-found-command/not-found-command.strest.yml
@@ -25,3 +25,5 @@ requests:
         expect: FATAL
       - jsonpath: content.result.programs[0].processes[0].state
         expect: FATAL
+      - jsonpath: content.result.programs[0].processes[0].pid
+        regex: ^0


### PR DESCRIPTION
If the process is currently running, and if we can get its PID, we return it. Otherwise we just return a `0`.

Closes #58 