### PR TITLE
Always restart until starttries is reached when being on backoff state

### DIFF
--- a/taskmaster.yaml
+++ b/taskmaster.yaml
@@ -28,7 +28,7 @@ programs:
     - 0
     - 2
     startretries: 3
-    starttime: 10
+    starttime: 12
     stopsignal: QUIT
     stoptime: 10
     stdout: /tmp/nginx.stdout

--- a/tests/launch-tests.sh
+++ b/tests/launch-tests.sh
@@ -72,7 +72,7 @@ testNotFoundCommand() {
 
 }
 
-testCreateProgram() {
+testCreate() {
     cd create-program
     rm -f taskmasterd.log
 
@@ -85,8 +85,21 @@ testCreateProgram() {
     assertFalse "Files should have been modified but were not" $?
 }
 
-testVersionProgram() {
+testVersion() {
     cd version
+    rm -f taskmasterd.log
+
+    ./test.sh
+
+    assertTrue $?
+
+    git diff --exit-code . > /dev/null
+
+    assertTrue "Files should have not been modified but were" $?
+}
+
+testAutomaticallyRestartOnBackoffState() {
+    cd automatically-restart-on-backoff-state
     rm -f taskmasterd.log
 
     ./test.sh

--- a/tests/scenarios/automatically-restart-on-backoff-state/automatically-restart-on-backoff-state.strest.yml
+++ b/tests/scenarios/automatically-restart-on-backoff-state/automatically-restart-on-backoff-state.strest.yml
@@ -6,21 +6,37 @@ requests:
       postData:
         mimeType: application/json
         text:
-          program_id: unknown-command
+          program_id: exited
     validate:
       - jsonpath: status
         expect: 200
-  running-status:
+  starting-status:
     request:
       url: http://localhost:8080/status
       method: GET
-    delay: 1000
+    delay: 1_000
     maxRetries: 2
     validate:
       - jsonpath: content.result.programs.length
         expect: 1
       - jsonpath: content.result.programs[0].id
-        expect: unknown-command
+        expect: exited
+      - jsonpath: content.result.programs[0].state
+        expect: STARTING
+      - jsonpath: content.result.programs[0].processes[0].state
+        expect: STARTING
+      - jsonpath: content.result.programs[0].processes[0].pid
+        expect: 0
+  fatal-status:
+    request:
+      url: http://localhost:8080/status
+      method: GET
+    delay: 40_000
+    validate:
+      - jsonpath: content.result.programs.length
+        expect: 1
+      - jsonpath: content.result.programs[0].id
+        expect: exited
       - jsonpath: content.result.programs[0].state
         expect: FATAL
       - jsonpath: content.result.programs[0].processes[0].state

--- a/tests/scenarios/automatically-restart-on-backoff-state/taskmaster.yaml
+++ b/tests/scenarios/automatically-restart-on-backoff-state/taskmaster.yaml
@@ -1,0 +1,11 @@
+programs:
+  exited:
+    cmd: "bin_exited"
+    autostart: false
+    autorestart: "unexpected"
+    exitcodes:
+    - 0
+    - 2
+    startretries: 2
+    starttime: 15
+    stoptime: 10

--- a/tests/scenarios/automatically-restart-on-backoff-state/test.sh
+++ b/tests/scenarios/automatically-restart-on-backoff-state/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+taskmasterd 2> /dev/null
+
+strest automatically-restart-on-backoff-state.strest.yml

--- a/tests/scenarios/infinite/infinite.strest.yml
+++ b/tests/scenarios/infinite/infinite.strest.yml
@@ -52,7 +52,7 @@ requests:
       - jsonpath: content.result.programs[0].processes[0].state
         expect: STOPPING
       - jsonpath: content.result.programs[0].processes[0].pid
-        regex: ^0
+        expect: 0
   still-stopping-after-2-seconds:
     request:
       url: http://localhost:8080/status
@@ -68,7 +68,7 @@ requests:
       - jsonpath: content.result.programs[0].processes[0].state
         expect: STOPPING
       - jsonpath: content.result.programs[0].processes[0].pid
-        regex: ^0
+        expect: 0
   still-stopping-after-5-seconds:
     request:
       url: http://localhost:8080/status
@@ -84,7 +84,7 @@ requests:
       - jsonpath: content.result.programs[0].processes[0].state
         expect: STOPPING
       - jsonpath: content.result.programs[0].processes[0].pid
-        regex: ^0
+        expect: 0
   stopped-after-11-seconds:
     request:
       url: http://localhost:8080/status
@@ -100,4 +100,4 @@ requests:
       - jsonpath: content.result.programs[0].processes[0].state
         expect: STOPPED
       - jsonpath: content.result.programs[0].processes[0].pid
-        regex: ^0
+        expect: 0


### PR DESCRIPTION
In the backoff state action, we don't care of the `autorestart` value.
We always restart unless we reached `starttries`.

It is for `EXITED` state that we must take care of `autorestart` value.