### PR TITLE
Make Start and Stop Chronometer synchronous

### DIFF
--- a/cmd/taskmasterd/process.go
+++ b/cmd/taskmasterd/process.go
@@ -219,25 +219,21 @@ func (process *Process) GetContext() context.Context {
 }
 
 func (process *Process) StartChronometer() {
-	go func() {
-		select {
-		case process.internalMonitorChannel <- ProcessTaskActionStartChronometer:
-			return
-		case <-process.context.Done():
-			return
-		}
-	}()
+	select {
+	case process.internalMonitorChannel <- ProcessTaskActionStartChronometer:
+		return
+	case <-process.context.Done():
+		return
+	}
 }
 
 func (process *Process) StopChronometer() {
-	go func() {
-		select {
-		case process.internalMonitorChannel <- ProcessTaskActionStopChronometer:
-			return
-		case <-process.context.Done():
-			return
-		}
-	}()
+	select {
+	case process.internalMonitorChannel <- ProcessTaskActionStopChronometer:
+		return
+	case <-process.context.Done():
+		return
+	}
 }
 
 func (process *Process) Start() {


### PR DESCRIPTION
When those functions are not blocking, it occurs that the `endedAt` property is never set for some randomly distributed processes.

Closes #76 