### PR TITLE
Ensure exitcodes range and fail on unknown type

### DIFF
--- a/cmd/taskmasterd/http.go
+++ b/cmd/taskmasterd/http.go
@@ -111,7 +111,7 @@ func httpEndpointStatus(taskmasterd *Taskmasterd, w http.ResponseWriter, r *http
 		}
 
 		httpPrograms := HttpPrograms{
-			Programs: make([]HttpProgram, 0),
+			Programs: make([]HttpProgram, 0, len(programs)),
 		}
 		for _, program := range programs {
 			processes, err := program.GetSortedProcesses()
@@ -460,7 +460,7 @@ func httpEndpointCreateProgram(taskmasterd *Taskmasterd, w http.ResponseWriter, 
 			}, w)
 			return
 		}
-		
+
 		RespondJSON(HttpJSONResponse{}, w)
 	default:
 		w.WriteHeader(http.StatusMethodNotAllowed)


### PR DESCRIPTION
We validate `exitcodes` range and fail validation if an unknown type is provided to `exitcodes` property
Closes #81 

We copy `workingdir` and `umask` values to the output structure.
Closes #80