### PR TITLE
Let the system release stdout and stderr manually

### DIFF
--- a/cmd/taskmasterd/process_actions.go
+++ b/cmd/taskmasterd/process_actions.go
@@ -130,13 +130,6 @@ func ProcessStartAction(stateMachine *machine.Machine, context machine.Context) 
 
 		process.StopChronometer()
 
-		if err := process.CloseFileDescriptors(); err != nil {
-			log.Printf(
-				"error while closing opened file descriptors of stdout and stderr: %v\n",
-				err,
-			)
-		}
-
 		_, err := stateMachine.Send(ProcessEventStopped)
 		if err != nil {
 			log.Printf("expected no error to be returned but got %v\n", err)

--- a/cmd/taskmasterd/task.go
+++ b/cmd/taskmasterd/task.go
@@ -56,7 +56,6 @@ const (
 	ProcessTaskActionGetStateMachineCurrentState TaskAction = "PROCESS_GET_STATE_MACHINE_CURRENT_STATE"
 	ProcessTaskActionSetCmd                      TaskAction = "PROCESS_SET_CMD"
 	ProcessTaskActionSetStdoutStderrCloser       TaskAction = "PROCESS_SET_STDOUT_STDERR_CLOSER"
-	ProcessTaskActionCloseFileDescriptors        TaskAction = "PROCESS_CLOSE_FILE_DESCRIPTORS"
 	ProcessTaskActionStart                       TaskAction = "PROCESS_START"
 	ProcessTaskActionStop                        TaskAction = "PROCESS_STOP"
 	ProcessTaskActionRestart                     TaskAction = "PROCESS_RESTART"


### PR DESCRIPTION
When testing with a large number of processes,
for some of them if try to close the file descriptors we get an error
saying that they have already been closed.
The [official documentation](https://golang.org/pkg/os/exec/#Cmd.Wait)
of (*Cmd).Wait says that it automatically releases all
associated resources.

Closes #78 