### PR TITLE
Signal an error using stopped event instead of fatal event

### DIFF
--- a/cmd/taskmasterd/process_actions.go
+++ b/cmd/taskmasterd/process_actions.go
@@ -61,7 +61,7 @@ func ProcessStartAction(stateMachine *machine.Machine, context machine.Context) 
 	expandedCommand := os.ExpandEnv(config.Cmd)
 	parsedCommand, err := parser.ParseCommand(expandedCommand)
 	if err != nil {
-		return ProcessEventFatal, err
+		return ProcessEventStopped, nil
 	}
 
 	cmd := exec.CommandContext(
@@ -77,13 +77,13 @@ func ProcessStartAction(stateMachine *machine.Machine, context machine.Context) 
 
 	stdout, err := config.CreateCmdStdout(serializedProcess.ID)
 	if err != nil {
-		return ProcessEventFatal, nil
+		return ProcessEventStopped, nil
 	}
 	cmd.Stdout = stdout
 
 	stderr, err := config.CreateCmdStderr(serializedProcess.ID)
 	if err != nil {
-		return ProcessEventFatal, nil
+		return ProcessEventStopped, nil
 	}
 	cmd.Stderr = stderr
 


### PR DESCRIPTION
The state machine does not anymore have a transition from starting state
to backoff state based on fatal event.
We must use `STOPPED` event.

We replaced the bad event with the good one for another error case in addition to stdout/stderr.

Closes #83 