### PR TITLE
Always create fresh deadCh and close it when process could not be started

### DIFF
--- a/cmd/taskmasterd/process_actions.go
+++ b/cmd/taskmasterd/process_actions.go
@@ -93,6 +93,8 @@ func ProcessStartAction(stateMachine *machine.Machine, context machine.Context) 
 
 	process.SetCmd(cmd)
 
+	deadCh := process.CreateNewDeadChannel()
+
 	SetUmask(config.Umask)
 	if err := cmd.Start(); err != nil {
 		log.Printf(
@@ -104,13 +106,13 @@ func ProcessStartAction(stateMachine *machine.Machine, context machine.Context) 
 
 		ResetUmask()
 
+		close(deadCh)
+
 		return ProcessEventStopped, nil
 	}
 	ResetUmask()
 
 	process.StartChronometer()
-
-	deadCh := process.CreateNewDeadChannel()
 
 	go func() {
 		select {


### PR DESCRIPTION
A new deadCh was created after the process had been started correctly.
When we try to restart a program, we wait for it to be stopped by waiting a value from deadCh.
The deadCh was not recreated so it was the previous deadCh. And if the process had never been started correctly, it was nil.
Reading on a nil channel blocks forever so the process was never started.

In this PR we ensure that a new deadCh is always created when starting a process.
We close this channel if the process could not be started, so that we can restart it.

Closes #89 