### PR TITLE
Use unsafe method to get process state

### DIFF
--- a/cmd/taskmasterd/process.go
+++ b/cmd/taskmasterd/process.go
@@ -173,7 +173,7 @@ func (process *Process) monitor() {
 				taskWithResponse := task.(ProcessInternalTaskWithResponse)
 				responseChan := taskWithResponse.ResponseChan
 
-				responseChan <- process.machine.Current()
+				responseChan <- process.machine.UnsafeCurrent()
 
 				close(responseChan)
 			case ProcessTaskActionSetCmd:


### PR DESCRIPTION
We reach a deadlock when ProcessStartAction and machine.Current
compete for mutex lock.
The easiest way to fix the deadlock is to use unsafe method
to get the processs state.