### PR TITLE
Log all state transitions

### DIFF
--- a/cmd/taskmasterd/process_actions.go
+++ b/cmd/taskmasterd/process_actions.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -45,6 +46,14 @@ func (err *ErrProcessStopping) Unwrap() error {
 
 func (err *ErrProcessStopping) Error() string {
 	return "stopping: " + err.Err.Error()
+}
+
+type ErrStrartretriesReached struct {
+	Startretries int
+}
+
+func (err *ErrStrartretriesReached) Error() string {
+	return fmt.Sprintf("reached maximum startries: %d", err.Startretries)
 }
 
 func ProcessStartAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
@@ -97,12 +106,7 @@ func ProcessStartAction(stateMachine *machine.Machine, context machine.Context) 
 
 	SetUmask(config.Umask)
 	if err := cmd.Start(); err != nil {
-		log.Printf(
-			"Error starting process '%s' of program '%s': %s",
-			config.Name,
-			serializedProcess.ID,
-			err.Error(),
-		)
+		processContext.LastError = err
 
 		ResetUmask()
 
@@ -132,10 +136,7 @@ func ProcessStartAction(stateMachine *machine.Machine, context machine.Context) 
 
 		process.StopChronometer()
 
-		_, err := stateMachine.Send(ProcessEventStopped)
-		if err != nil {
-			log.Printf("expected no error to be returned but got %v\n", err)
-		}
+		stateMachine.Send(ProcessEventStopped)
 	}()
 
 	return machine.NoopEvent, nil
@@ -182,23 +183,13 @@ func ProcessBackoffAction(stateMachine *machine.Machine, context machine.Context
 		return machine.NoopEvent, err
 	}
 
-	serializedProcess := process.Serialize()
-
 	if processContext.Starttries >= config.Startretries {
-		log.Printf(
-			"Fatal: could not start process '%s' of program '%s' (%d tries)",
-			serializedProcess.ID,
-			config.Name,
-			processContext.Starttries,
-		)
+		processContext.LastError = &ErrStrartretriesReached{
+			Startretries: processContext.Starttries,
+		}
+
 		return ProcessEventFatal, nil
 	}
-
-	log.Printf(
-		"Trying to restart process '%s' of program '%s'...",
-		serializedProcess.ID,
-		config.Name,
-	)
 
 	processContext.Starttries++
 
@@ -214,16 +205,10 @@ func ProcessExitedAction(stateMachine *machine.Machine, context machine.Context)
 		return machine.NoopEvent, err
 	}
 
-	serializedProcess := process.Serialize()
-
 	switch config.Autorestart {
 	case AutorestartOn:
-		log.Printf(
-			"Trying to restart process '%s' of program '%s'...",
-			serializedProcess.ID,
-			config.Name,
-		)
 		return ProcessEventStart, nil
+
 	case AutorestartUnexpected:
 		exitcode := process.GetCmd().ProcessState.ExitCode()
 		for _, allowedExitcode := range config.Exitcodes {
@@ -232,12 +217,8 @@ func ProcessExitedAction(stateMachine *machine.Machine, context machine.Context)
 			}
 		}
 
-		log.Printf(
-			"Trying to restart process '%s' of program '%s'...",
-			serializedProcess.ID,
-			config.Name,
-		)
 		return ProcessEventStart, nil
+
 	default:
 		return machine.NoopEvent, nil
 	}
@@ -251,6 +232,15 @@ func ProcessResetStarttriesAction(stateMachine *machine.Machine, context machine
 }
 
 func PrintCurrentStateAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
+	var (
+		processContext = context.(*ProcessMachineContext)
+		process        = processContext.Process
+	)
+
+	defer func() {
+		processContext.LastError = nil
+	}()
+
 	sentenceForState := map[machine.StateType]string{
 		ProcessStateStarting: "is starting",
 		ProcessStateBackoff:  "is backing off",
@@ -261,22 +251,30 @@ func PrintCurrentStateAction(stateMachine *machine.Machine, context machine.Cont
 		ProcessStateFatal:    "has fataly exited",
 	}
 
-	processContext := context.(*ProcessMachineContext)
-	process := processContext.Process
-
 	config, err := process.GetConfig()
 	if err != nil {
 		return machine.NoopEvent, err
 	}
 
 	serializedProcess := process.Serialize()
+	currentState := stateMachine.UnsafeCurrent()
 
-	log.Printf(
-		"Process '%s' of program '%s' %s\n",
-		serializedProcess.ID,
-		config.Name,
-		sentenceForState[stateMachine.UnsafeCurrent()],
-	)
+	if err := processContext.LastError; err != nil {
+		log.Printf(
+			"Process '%s' of program '%s' %s (%s)\n",
+			serializedProcess.ID,
+			config.Name,
+			sentenceForState[currentState],
+			err,
+		)
+	} else {
+		log.Printf(
+			"Process '%s' of program '%s' %s\n",
+			serializedProcess.ID,
+			config.Name,
+			sentenceForState[currentState],
+		)
+	}
 
 	return machine.NoopEvent, nil
 }

--- a/cmd/taskmasterd/process_actions.go
+++ b/cmd/taskmasterd/process_actions.go
@@ -249,3 +249,34 @@ func ProcessResetStarttriesAction(stateMachine *machine.Machine, context machine
 
 	return machine.NoopEvent, nil
 }
+
+func PrintCurrentStateAction(stateMachine *machine.Machine, context machine.Context) (machine.EventType, error) {
+	sentenceForState := map[machine.StateType]string{
+		ProcessStateStarting: "is starting",
+		ProcessStateBackoff:  "is backing off",
+		ProcessStateRunning:  "is running",
+		ProcessStateStopping: "is stopping",
+		ProcessStateStopped:  "is stopped",
+		ProcessStateExited:   "has exited",
+		ProcessStateFatal:    "has fataly exited",
+	}
+
+	processContext := context.(*ProcessMachineContext)
+	process := processContext.Process
+
+	config, err := process.GetConfig()
+	if err != nil {
+		return machine.NoopEvent, err
+	}
+
+	serializedProcess := process.Serialize()
+
+	log.Printf(
+		"Process '%s' of program '%s' %s\n",
+		serializedProcess.ID,
+		config.Name,
+		sentenceForState[stateMachine.UnsafeCurrent()],
+	)
+
+	return machine.NoopEvent, nil
+}

--- a/cmd/taskmasterd/process_machine.go
+++ b/cmd/taskmasterd/process_machine.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/42Taskmaster/taskmaster/machine"
+import (
+	"github.com/42Taskmaster/taskmaster/machine"
+)
 
 const (
 	ProcessStateStarting machine.StateType = "STARTING"
@@ -37,6 +39,10 @@ func NewProcessMachine(process *Process) *machine.Machine {
 
 		StateNodes: machine.StateNodes{
 			ProcessStateStopped: machine.StateNode{
+				Actions: []machine.Action{
+					PrintCurrentStateAction,
+				},
+
 				On: machine.Events{
 					ProcessEventStart: ProcessStateStarting,
 				},
@@ -44,6 +50,7 @@ func NewProcessMachine(process *Process) *machine.Machine {
 
 			ProcessStateStarting: machine.StateNode{
 				Actions: []machine.Action{
+					PrintCurrentStateAction,
 					ProcessStartAction,
 				},
 
@@ -56,6 +63,7 @@ func NewProcessMachine(process *Process) *machine.Machine {
 
 			ProcessStateBackoff: machine.StateNode{
 				Actions: []machine.Action{
+					PrintCurrentStateAction,
 					ProcessBackoffAction,
 				},
 
@@ -67,6 +75,7 @@ func NewProcessMachine(process *Process) *machine.Machine {
 
 			ProcessStateRunning: machine.StateNode{
 				Actions: []machine.Action{
+					PrintCurrentStateAction,
 					ProcessResetStarttriesAction,
 				},
 
@@ -78,6 +87,7 @@ func NewProcessMachine(process *Process) *machine.Machine {
 
 			ProcessStateStopping: machine.StateNode{
 				Actions: []machine.Action{
+					PrintCurrentStateAction,
 					ProcessStopAction,
 					ProcessResetStarttriesAction,
 				},
@@ -89,6 +99,7 @@ func NewProcessMachine(process *Process) *machine.Machine {
 
 			ProcessStateExited: machine.StateNode{
 				Actions: []machine.Action{
+					PrintCurrentStateAction,
 					ProcessExitedAction,
 				},
 
@@ -99,6 +110,7 @@ func NewProcessMachine(process *Process) *machine.Machine {
 
 			ProcessStateFatal: machine.StateNode{
 				Actions: []machine.Action{
+					PrintCurrentStateAction,
 					ProcessResetStarttriesAction,
 				},
 

--- a/cmd/taskmasterd/process_machine.go
+++ b/cmd/taskmasterd/process_machine.go
@@ -26,6 +26,7 @@ const (
 type ProcessMachineContext struct {
 	Process    Processer
 	Starttries int
+	LastError  error
 }
 
 func NewProcessMachine(process *Process) *machine.Machine {


### PR DESCRIPTION
We simplify the process by logging all state transitions.
To provide more information, an action can store an error in the state machine context, which will be automatically used when printing.

Closes #93 